### PR TITLE
Adds language_code flag to bulk_create_entity_from_dataframe and create_entity_type

### DIFF
--- a/src/dfcx_scrapi/core/entity_types.py
+++ b/src/dfcx_scrapi/core/entity_types.py
@@ -162,17 +162,19 @@ class EntityTypes(ScrapiBase):
         client = services.entity_types.EntityTypesClient(
             credentials=self.creds, client_options=client_options
         )
+
+        request = types.entity_type.CreateEntityTypeRequest(
+            agent_id,
+            entity_type)
+
         if language_code:
-            response = client.create_entity_type(
-                parent=agent_id,
-                entity_type=entity_type,
-                language_code=language_code
-            )
-        else:
-            response = client.create_entity_type(
-                parent=agent_id,
-                entity_type=entity_type
-            )
+            request.language_code = language_code
+
+        response = client.create_entity_type(
+            request=request,
+            parent=agent_id,
+            entity_type=entity_type
+        )
 
         return response
 

--- a/src/dfcx_scrapi/core/entity_types.py
+++ b/src/dfcx_scrapi/core/entity_types.py
@@ -130,7 +130,8 @@ class EntityTypes(ScrapiBase):
         return response
 
     def create_entity_type(
-        self, agent_id: str = None, obj: types.EntityType = None, **kwargs
+        self, agent_id: str = None, obj: types.EntityType = None,
+        language_code: str = None, **kwargs
     ) -> types.EntityType:
         """Creates a single Entity Type object resource.
 
@@ -158,9 +159,18 @@ class EntityTypes(ScrapiBase):
         client = services.entity_types.EntityTypesClient(
             credentials=self.creds, client_options=client_options
         )
-        response = client.create_entity_type(
-            parent=agent_id, entity_type=entity_type
-        )
+        if language_code:
+            response = client.create_entity_type(
+                parent=agent_id,
+                entity_type=entity_type,
+                language_code=language_code
+            )
+        else:
+            response = client.create_entity_type(
+                parent=agent_id,
+                entity_type=entity_type
+            )
+
         return response
 
     def update_entity_type(

--- a/src/dfcx_scrapi/core/entity_types.py
+++ b/src/dfcx_scrapi/core/entity_types.py
@@ -163,17 +163,16 @@ class EntityTypes(ScrapiBase):
             credentials=self.creds, client_options=client_options
         )
 
-        request = types.entity_type.CreateEntityTypeRequest(
-            agent_id,
-            entity_type)
+        request = types.entity_type.CreateEntityTypeRequest()
+
+        request.parent = agent_id
+        request.entity_type = entity_type
 
         if language_code:
             request.language_code = language_code
 
         response = client.create_entity_type(
-            request=request,
-            parent=agent_id,
-            entity_type=entity_type
+            request=request
         )
 
         return response

--- a/src/dfcx_scrapi/core/entity_types.py
+++ b/src/dfcx_scrapi/core/entity_types.py
@@ -137,6 +137,9 @@ class EntityTypes(ScrapiBase):
 
         Args:
           - agent_id, the formatted CX Agent ID to create the object on
+          - obj, The CX EntityType object in proper format.
+          - language_code: Language code of the intents being uploaded. Ref:
+            https://cloud.google.com/dialogflow/cx/docs/reference/language
 
         Returns:
           - response, copy of the Entity Type object created

--- a/src/dfcx_scrapi/tools/dataframe_functions.py
+++ b/src/dfcx_scrapi/tools/dataframe_functions.py
@@ -795,8 +795,9 @@ class DataframeFunctions(scrapi_base.ScrapiBase):
         return entity_pb
 
     def bulk_create_entity_from_dataframe(
-        self, agent_id, entities_df, update_flag=False, rate_limiter=5,
-        language_code: str = None
+        self, agent_id, entities_df, update_flag=False,
+        language_code: str = None, rate_limiter=5,
+
     ):
         """Bulk create entities from a dataframe.
 

--- a/src/dfcx_scrapi/tools/dataframe_functions.py
+++ b/src/dfcx_scrapi/tools/dataframe_functions.py
@@ -795,7 +795,8 @@ class DataframeFunctions(scrapi_base.ScrapiBase):
         return entity_pb
 
     def bulk_create_entity_from_dataframe(
-        self, agent_id, entities_df, update_flag=False, rate_limiter=5
+        self, agent_id, entities_df, update_flag=False, rate_limiter=5,
+        language_code: str = None
     ):
         """Bulk create entities from a dataframe.
 
@@ -839,7 +840,9 @@ class DataframeFunctions(scrapi_base.ScrapiBase):
 
             if update_flag:
                 self.entities.create_entity_type(
-                    agent_id=agent_id, obj=new_entity
+                    agent_id=agent_id,
+                    obj=new_entity,
+                    language_code=language_code,
                 )
                 time.sleep(rate_limiter)
 

--- a/src/dfcx_scrapi/tools/dataframe_functions.py
+++ b/src/dfcx_scrapi/tools/dataframe_functions.py
@@ -807,6 +807,8 @@ class DataframeFunctions(scrapi_base.ScrapiBase):
           entities_df: dataframe of bulk entities;
             required columns: display_name, value, synonyms
           update_flag: True to update_flag the entities in the agent
+          language_code: Language code of the intents being uploaded. Ref:
+            https://cloud.google.com/dialogflow/cx/docs/reference/language
           rate_limiter: seconds to sleep between operations.
 
         Returns:


### PR DESCRIPTION
## Description
`bulk_create_entity_from_dataframe` needs to have functionality to support multiple languages. This PR adds this functionality in a similar manner as `update_intents` in intents.py.

## Type of change
Please delete options that are not relevant.
 
* [ ]  Bug fix (non-breaking change which fixes an issue)
* [x]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change requires a documentation update

## How Has This Been Tested?
I tested this out with a test DFCX agent which supports multiple languages. I am blocked from testing it fully due to issue #11 

## Checklist:
* [x]  My code follows the style guidelines of this project
* [x]  I have performed a self-review of my own code
* [x]  I have commented my code, particularly in hard-to-understand areas

