### PR TITLE
Advanced mode did not manage properly unannotated training phrases

### DIFF
--- a/data/intent_sample_params.csv
+++ b/data/intent_sample_params.csv
@@ -1,0 +1,2 @@
+display_name,id,entity_type
+head_intent.order_pizza,numberOfPizza,projects/-/locations/-/agents/-/entityTypes/sys.number

--- a/data/intent_sample_with_parts.csv
+++ b/data/intent_sample_with_parts.csv
@@ -2,8 +2,8 @@ display_name,training_phrase,part,text,parameter_id
 head_intent.order_pizza,0,0,I want to order a pizza,
 head_intent.order_pizza,1,0,I\'d like a cheese pizza with pepporoni please!,
 head_intent.order_pizza,2,0,A slice of cheese with extra basil,
-head_intent.order_pizza,3,0,2,numberOfPizza
+head_intent.order_pizza,3,0,2 ,numberOfPizza
 head_intent.order_pizza,3,1,large thin crust extra pepp add olives,
-head_intent.order_pizza,4,0,I need to place an order for,
-head_intent.order_pizza,4,1,15,numberOfPizza
+head_intent.order_pizza,4,0,I need to place an order for ,
+head_intent.order_pizza,4,1,15 ,numberOfPizza
 head_intent.order_pizza,4,2,large cheese pizzas for a birthday party!,

--- a/data/intent_sample_with_parts.csv
+++ b/data/intent_sample_with_parts.csv
@@ -1,0 +1,9 @@
+display_name,training_phrase,part,text,parameter_id
+head_intent.order_pizza,0,0,I want to order a pizza,
+head_intent.order_pizza,1,0,I\'d like a cheese pizza with pepporoni please!,
+head_intent.order_pizza,2,0,A slice of cheese with extra basil,
+head_intent.order_pizza,3,0,2,numberOfPizza
+head_intent.order_pizza,3,1,large thin crust extra pepp add olives,
+head_intent.order_pizza,4,0,I need to place an order for,
+head_intent.order_pizza,4,1,15,numberOfPizza
+head_intent.order_pizza,4,2,large cheese pizzas for a birthday party!,

--- a/examples/bot_building_series/bot_building_102-intents-with-annotated_tp.ipynb
+++ b/examples/bot_building_series/bot_building_102-intents-with-annotated_tp.ipynb
@@ -1,0 +1,212 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright 2021 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Introduction\n",
+    "In this notebook, we will show you how to build a Dialogflow CX Agent from scratch using plain text inputs and a simple CSV file.\n",
+    "\n",
+    "In this example some of the training phrases will be anotated with the @sys.number entity\n",
+    "\n",
+    "## Prerequisites\n",
+    "- Ensure you have a GCP Service Account key with the Dialogflow API Admin privileges assigned to it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#If you haven't already, make sure you install the `dfcx-scrapi` library\n",
+    "#Link to the GitHub repo: https://github.com/GoogleCloudPlatform/dfcx-scrapi\n",
+    "\n",
+    "!pip install --user dfcx-scrapi\n",
+    "!pip install --user -r ./dfcx-scrapi/requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from dfcx_scrapi.core.agents import Agents\n",
+    "from dfcx_scrapi.core.intents import Intents\n",
+    "from dfcx_scrapi.core.flows import Flows\n",
+    "from dfcx_scrapi.core.pages import Pages\n",
+    "from dfcx_scrapi.tools.dataframe_functions import DataframeFunctions\n",
+    "from dfcx_scrapi.tools.maker_util import MakerUtil\n",
+    "\n",
+    "#Input here your Service Account Key path\n",
+    "creds_path = '/PATH/TO/YOU/KEY.JSON'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Method 1 - Creating an Agent from Simple Text Inputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Your Agent\n",
+    "Creating an agent requires a minimum of 2 pieces of information:\n",
+    "- `project_id`, which is your GCP Project ID\n",
+    "- `display_name`, (i.e. 'My Cool Agent!')\n",
+    "- `gcp_region`, (Optional) This defaults to `global` region, but you can provide any GCP region that is currently available for Dialogflow CX."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First we will instantiate our Agent object\n",
+    "a = Agents(creds_path=creds_path)\n",
+    "\n",
+    "# Next, we will set some variables for our agent creation or retrieval args\n",
+    "project_id = '<PROJECT_ID>'\n",
+    "display_name = 'My Awesome Agent!'\n",
+    "gcp_region = '<GCP_REGION>' #(eg. 'global', 'us-cenral1', etc... See region availability for DFCX at https://cloud.google.com/dialogflow/cx/docs/concept/region\n",
+    "\n",
+    "# Then we will call the `create_agent` or get_agent method (if agent already exists) and capture the result in a var call `my_agent`\n",
+    "#Option 1: If agent does not exist\n",
+    "#my_agent = a.create_agent(project_id, display_name, gcp_region)\n",
+    "\n",
+    "#Option 2: If agent already exists\n",
+    "#The agent ID must be entered as a string \"projects/<PROJECT_ID>/locations/<GCP_REGION>/agents/<AGENT_ID>\"\n",
+    "my_agent = a.get_agent(\"projects/<PROJECT_ID>/locations/<GCP_REGION>/agents/<AGENT_ID>\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you inspect your `my_agent` variable, you will see it is of types.agent.Agent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_agent"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Your First Intent\n",
+    "For this demo agent, we'll build a basic intent from list of Training Phrases (TPs)\n",
+    "\n",
+    "To simplify the Intent creation, we'll utilize the `DataframeFunctions` class from the `tools` portion of the SCRAPI library.   \n",
+    "This will allow us to build our intent into a simple Pandas DataFrame, and then push this DataFrame directly into our bot that we just created.\n",
+    "\n",
+    "A common method of building Intents and Training Phrases for Dialogflow CX agents is to use Google Sheets or CSVs to store the Intent/TP data.  \n",
+    "For this demo, we are working with annotated training phrases. To do so, we've included \n",
+    "* `intent_sample_with_parts.csv` which contains all the training phrases parts. It will be pulled into a dataframe \n",
+    "* `intent_sample_params`, that defines the parameters used for each intent. It will also be pulled into a dataframe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First, we will instantiate our DataframeFunctions (dffx) object\n",
+    "dffx = DataframeFunctions(creds_path=creds_path)\n",
+    "\n",
+    "# Next, we will read in our sample CSV with Intent training phrases data as well as the entities used into 2 distinct Pandas DataFrames\n",
+    "df = pd.read_csv('../../data/intent_sample_with_parts.csv')\n",
+    "params_df = pd.read_csv('../../data/intent_sample_params.csv')\n",
+    "\n",
+    "# Finally, we will use `dffx` to push our Intents to our Agent\n",
+    "#If intents do not exist, use bulk_create_intent_from_dataframe\n",
+    "my_intents = dffx.bulk_create_intent_from_dataframe(my_agent.name, df, params_df, update_flag=True, mode=\"advanced\")\n",
+    "\n",
+    "#If intent already exist, use bulk_update_intents_from_dataframe\n",
+    "#my_intents = dffx.bulk_update_intents_from_dataframe(my_agent.name, df, params_df, update_flag=True, mode=\"advanced\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Bot Building 101 End\n",
+    "## And there you have it!   \n",
+    "We've created a simple Dialogflow CX agent using only Python in a Jupyter notebook.\n",
+    "You can see how this could be easily scaled up using .py files, git repos, and other scripts to speed up the bot building process."
+   ]
+  }
+ ],
+ "metadata": {
+  "environment": {
+   "kernel": "conda-env-python38-py",
+   "name": "common-cpu.m90",
+   "type": "gcloud",
+   "uri": "gcr.io/deeplearning-platform-release/base-cpu:m90"
+  },
+  "interpreter": {
+   "hash": "a46639dc4ce59764707f7d29e7ddf4b543fd040f828fe9a3cb5baeb9324df219"
+  },
+  "kernelspec": {
+   "display_name": "Python [conda env:python38]",
+   "language": "python",
+   "name": "conda-env-python38-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/bot_building_series/bot_building_102-intents-with-annotated_tp.ipynb
+++ b/examples/bot_building_series/bot_building_102-intents-with-annotated_tp.ipynb
@@ -172,7 +172,7 @@
     "tags": []
    },
    "source": [
-    "# Bot Building 101 End\n",
+    "# Bot Building 102 End\n",
     "## And there you have it!   \n",
     "We've created a simple Dialogflow CX agent using only Python in a Jupyter notebook.\n",
     "You can see how this could be easily scaled up using .py files, git repos, and other scripts to speed up the bot building process."

--- a/examples/bot_building_series/bot_building_102-intents-with-annotated_tp.py
+++ b/examples/bot_building_series/bot_building_102-intents-with-annotated_tp.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pandas as pd
+from dfcx_scrapi.core.agents import Agents
+from dfcx_scrapi.core.intents import Intents
+from dfcx_scrapi.core.flows import Flows
+from dfcx_scrapi.core.pages import Pages
+from dfcx_scrapi.tools.dataframe_functions import DataframeFunctions
+from dfcx_scrapi.tools.maker_util import MakerUtil
+
+
+# # Method 1 - Creating an Agent from Simple Text Inputs
+
+# ## Create Your Agent
+# Creating an agent requires a minimum of 2 pieces of information:
+# - `project_id`, which is your GCP Project ID
+# - `display_name`, (i.e. 'My Cool Agent!')
+# - `gcp_region`, (Optional) This defaults to `global` region, but you can provide any GCP region that is currently available for Dialogflow CX.
+
+def build_agent(creds_path, project_id, gcp_region, display_name)
+
+	# First we will instantiate our Agent object
+	a = Agents(creds_path=creds_path)
+
+	# Next, we will set some variables for our agent creation or retrieval args
+
+	# Then we will call the `create_agent` and capture the result in a var call `my_agent`
+	my_agent = a.create_agent(project_id, display_name, gcp_region)
+
+	#Option 2: If agent already exists
+	#The agent ID must be entered as a string "projects/<PROJECT_ID>/locations/<GCP_REGION>/agents/<AGENT_ID>"
+	#my_agent = a.get_agent("projects/<PROJECT_ID>/locations/<GCP_REGION>/agents/<AGENT_ID>")
+
+
+	# ## Create Your First Intent
+	# For this demo agent, we'll build a basic intent from list of Training Phrases (TPs)
+	# 
+	# To simplify the Intent creation, we'll utilize the `DataframeFunctions` class from the `tools` portion of the SCRAPI library.   
+	# This will allow us to build our intent into a simple Pandas DataFrame, and then push this DataFrame directly into our bot that we just created.
+	# 
+	# A common method of building Intents and Training Phrases for Dialogflow CX agents is to use Google Sheets or CSVs to store the Intent/TP data.  
+	# For this demo, we are working with annotated training phrases. To do so, we've included 
+	# * `intent_sample_with_parts.csv` which contains all the training phrases parts. It will be pulled into a dataframe 
+	# * `intent_sample_params`, that defines the parameters used for each intent. It will also be pulled into a dataframe
+
+	# First, we will instantiate our DataframeFunctions (dffx) object
+	dffx = DataframeFunctions(creds_path=creds_path)
+
+	# Next, we will read in our sample CSV with Intent training phrases data as well as the entities used into 2 distinct Pandas DataFrames
+	df = pd.read_csv('../../data/intent_sample_with_parts.csv')
+	params_df = pd.read_csv('../../data/intent_sample_params.csv')
+
+	# Finally, we will use `dffx` to push our Intents to our Agent
+	#If intents do not exist, use bulk_create_intent_from_dataframe
+	my_intents = dffx.bulk_create_intent_from_dataframe(my_agent.name, df, params_df, update_flag=True, mode="advanced")
+
+	#If intent already exist, use bulk_update_intents_from_dataframe
+	#my_intents = dffx.bulk_update_intents_from_dataframe(my_agent.name, df, params_df, update_flag=True, mode="advanced")
+
+
+	# # Bot Building 101 End
+	# ## And there you have it!   
+	# We've created a simple Dialogflow CX agent using only Python in a Jupyter notebook.
+	# You can see how this could be easily scaled up using .py files, git repos, and other scripts to speed up the bot building process.
+
+
+#The agent ID must be entered as a string "projects/<PROJECT_ID>/locations/<GCP_REGION>/agents/<AGENT_ID>"
+def update_agent(creds_path, agent_id)
+	# First we will instantiate our Agent object and retrieve the agent using its id
+	a = Agents(creds_path=creds_path)
+	my_agent = a.get_agent("projects/<PROJECT_ID>/locations/<GCP_REGION>/agents/<AGENT_ID>")
+
+
+	# ## Create Your First Intent
+	# For this demo agent, we'll build a basic intent from list of Training Phrases (TPs)
+	# 
+	# To simplify the Intent creation, we'll utilize the `DataframeFunctions` class from the `tools` portion of the SCRAPI library.   
+	# This will allow us to build our intent into a simple Pandas DataFrame, and then push this DataFrame directly into our bot that we just created.
+	# 
+	# A common method of building Intents and Training Phrases for Dialogflow CX agents is to use Google Sheets or CSVs to store the Intent/TP data.  
+	# For this demo, we are working with annotated training phrases. To do so, we've included 
+	# * `intent_sample_with_parts.csv` which contains all the training phrases parts. It will be pulled into a dataframe 
+	# * `intent_sample_params`, that defines the parameters used for each intent. It will also be pulled into a dataframe
+
+	# First, we will instantiate our DataframeFunctions (dffx) object
+	dffx = DataframeFunctions(creds_path=creds_path)
+
+	# Next, we will read in our sample CSV with Intent training phrases data as well as the entities used into 2 distinct Pandas DataFrames
+	df = pd.read_csv('../../data/intent_sample_with_parts.csv')
+	params_df = pd.read_csv('../../data/intent_sample_params.csv')
+
+	#bulk update the existing intents
+	my_intents = dffx.bulk_update_intents_from_dataframe(my_agent.name, df, params_df, update_flag=True, mode="advanced")
+
+
+	# # Bot Building 102 End
+	# ## And there you have it!   
+	# We've created a simple Dialogflow CX agent using only Python in a Jupyter notebook.
+	# You can see how this could be easily scaled up using .py files, git repos, and other scripts to speed up the bot building process.
+
+if __name__ == '__main__':
+    CREDS_PATH = str(sys.argv[1])
+    PROJECT_ID = str(sys.argv[2])
+    build_agent(CREDS_PATH, PROJECT_ID)

--- a/src/dfcx_scrapi/tools/dataframe_functions.py
+++ b/src/dfcx_scrapi/tools/dataframe_functions.py
@@ -240,15 +240,10 @@ class DataframeFunctions(ScrapiBase):
                 ]
                 parts = []
                 for _, row in tp_parts.iterrows():
-                    if pd.isna(row["parameter_id"]):
-                        part = {
-                            "text": row["text"],
-                        }
-                    else:
-                        part = {
-                            "text": row["text"],
-                            "parameter_id": row["parameter_id"],
-                    }
+                    part = {
+                        "text": row["text"],
+                        "parameter_id": None if pd.isna(row["parameter_id"]) else row["parameter_id"],
+                }
                     parts.append(part)
 
                 training_phrase = {"parts": parts, "repeat_count": 1, "id": ""}
@@ -565,15 +560,10 @@ class DataframeFunctions(ScrapiBase):
                 ]
                 parts = []
                 for _, row in tp_parts.iterrows():
-                    if pd.isna(row["parameter_id"]):
-                        part = {
-                            "text": row["text"],
-                        }
-                    else:
-                        part = {
-                            "text": row["text"],
-                            "parameter_id": row["parameter_id"],
-                        }
+                    part = {
+                        "text": row["text"],
+                        "parameter_id": None if pd.isna(row["parameter_id"]) else row["parameter_id"],
+                    }
                     parts.append(part)
 
                 training_phrase = {"parts": parts, "repeat_count": 1, "id": ""}
@@ -592,7 +582,7 @@ class DataframeFunctions(ScrapiBase):
 
             if parameters:
                 intent["parameters"] = parameters
-                
+
         elif mode == "basic":
             training_phrases = []
             for _, row in tp_df.iterrows():
@@ -603,7 +593,7 @@ class DataframeFunctions(ScrapiBase):
             intent["training_phrases"] = training_phrases
         else:
             raise ValueError("mode must be basic or advanced")
-        
+
         json_intent = json.dumps(intent)
         intent_pb = types.Intent.from_json(json_intent)
 

--- a/src/dfcx_scrapi/tools/dataframe_functions.py
+++ b/src/dfcx_scrapi/tools/dataframe_functions.py
@@ -240,9 +240,14 @@ class DataframeFunctions(ScrapiBase):
                 ]
                 parts = []
                 for _, row in tp_parts.iterrows():
-                    part = {
-                        "text": row["text"],
-                        "parameter_id": row["parameter_id"],
+                    if pd.isna(row["parameter_id"]):
+                        part = {
+                            "text": row["text"],
+                        }
+                    else:
+                        part = {
+                            "text": row["text"],
+                            "parameter_id": row["parameter_id"],
                     }
                     parts.append(part)
 
@@ -560,10 +565,15 @@ class DataframeFunctions(ScrapiBase):
                 ]
                 parts = []
                 for _, row in tp_parts.iterrows():
-                    part = {
-                        "text": row["text"],
-                        "parameter_id": row["parameter_id"],
-                    }
+                    if pd.isna(row["parameter_id"]):
+                        part = {
+                            "text": row["text"],
+                        }
+                    else:
+                        part = {
+                            "text": row["text"],
+                            "parameter_id": row["parameter_id"],
+                        }
                     parts.append(part)
 
                 training_phrase = {"parts": parts, "repeat_count": 1, "id": ""}
@@ -582,7 +592,7 @@ class DataframeFunctions(ScrapiBase):
 
             if parameters:
                 intent["parameters"] = parameters
-
+                
         elif mode == "basic":
             training_phrases = []
             for _, row in tp_df.iterrows():
@@ -593,7 +603,7 @@ class DataframeFunctions(ScrapiBase):
             intent["training_phrases"] = training_phrases
         else:
             raise ValueError("mode must be basic or advanced")
-
+        
         json_intent = json.dumps(intent)
         intent_pb = types.Intent.from_json(json_intent)
 

--- a/src/dfcx_scrapi/tools/dataframe_functions.py
+++ b/src/dfcx_scrapi/tools/dataframe_functions.py
@@ -240,9 +240,10 @@ class DataframeFunctions(ScrapiBase):
                 ]
                 parts = []
                 for _, row in tp_parts.iterrows():
+                    param_id = row["parameter_id"]
                     part = {
                         "text": row["text"],
-                        "parameter_id": None if pd.isna(row["parameter_id"]) else row["parameter_id"],
+                        "parameter_id": None if pd.isna(param_id) else param_id,
                 }
                     parts.append(part)
 
@@ -560,9 +561,10 @@ class DataframeFunctions(ScrapiBase):
                 ]
                 parts = []
                 for _, row in tp_parts.iterrows():
+                    param_id = row["parameter_id"]
                     part = {
                         "text": row["text"],
-                        "parameter_id": None if pd.isna(row["parameter_id"]) else row["parameter_id"],
+                        "parameter_id": None if pd.isna(param_id) else param_id,
                     }
                     parts.append(part)
 


### PR DESCRIPTION
The bulk_create_intent_from_dataframe and bulk_update_intents_from_dataframe did not manage properly training phrases that had no annotations (parameter_id is NA).
Added a condition that solves the issue in src/dfcx_scrapi/tools/dataframe_functions.py file.

Also added an example: 

- a notebook and .py files to help understand how to work with annotated training phrases
- 2 CSV files for sample intent and params 