### PR TITLE
Conversation Class Enhancements and Bug Fixes

### DIFF
--- a/src/dfcx_scrapi/core/conversation.py
+++ b/src/dfcx_scrapi/core/conversation.py
@@ -110,7 +110,7 @@ class DialogflowConversation(scrapi_base.ScrapiBase):
         percent = float(current) * 100 / total
         arrow = "-" * int(percent / 100 * bar_length - 1) + ">"
         spaces = " " * (bar_length - len(arrow))
-        print(f"{type_}({current}/{total})" + f"[{arrow}{spaces}] {percent}%",
+        print(f"{type_}({current}/{total})" + f"[{arrow}{spaces}] {percent:.2f}%",
           end="\r")
 
     @staticmethod
@@ -132,10 +132,11 @@ class DialogflowConversation(scrapi_base.ScrapiBase):
     @staticmethod
     def _build_query_input_object(input_obj, language_code):
         if 'dtmf' in input_obj:
-            digits = input_obj['dtmf']
+            digits = str(input_obj['dtmf'])
 
+            finish_digit = None
             if 'finish_digit' in input_obj:
-                finish_digit = input_obj['dtmf_finish']
+                finish_digit = str(input_obj['finish_digit'])          
 
             dtmf_input = types.session.DtmfInput(
                 digits=digits, finish_digit=finish_digit)
@@ -143,6 +144,24 @@ class DialogflowConversation(scrapi_base.ScrapiBase):
                 dtmf=dtmf_input,
                 language_code=language_code,
                 )
+        
+        elif 'intent' in input_obj:
+            intent_input = types.session.IntentInput(
+                intent=input_obj['intent']
+            )
+            query_input = types.session.QueryInput(
+                intent=intent_input,
+                language_code=language_code
+            )
+
+        elif 'event' in input_obj:
+            event_input = types.session.EventInput(
+                event=input_obj['event']
+            )
+            query_input = types.session.QueryInput(
+                event=event_input,
+                language_code=language_code
+            )
                 
         elif 'text' in input_obj:
             text = input_obj['text']
@@ -555,5 +574,7 @@ class DialogflowConversation(scrapi_base.ScrapiBase):
             result = pd.concat([result, result_chunk])
             self.progress_bar(start, test_set.shape[0])
             time.sleep(rate_limit)
+
+        self.progress_bar(test_set.shape[0], test_set.shape[0])
 
         return result

--- a/src/dfcx_scrapi/core/conversation.py
+++ b/src/dfcx_scrapi/core/conversation.py
@@ -230,21 +230,22 @@ class DialogflowConversation(ScrapiBase):
 
     def reply(
         self,
-        send_obj,
+        send_obj: Dict[str,str],
         restart: bool = False,
-        raw: bool = False,
         retries: int = 0,
         current_page: str = None,
         checkpoints: bool = False
     ):
         """
         args:
-            send_obj  {text, params, dtmf}
+            send_obj: Dictionary with the following structure:
+              {'text': str, 
+               'params': Dict[str,str],
+               'dtmf': str}
             restart: Boolean flag that determines whether to use the existing
               session ID or start a new conversation with a new session ID.
               Passing True will create a new session ID on subsequent calls.
               Defaults to False.
-            raw: boolean
             retries: used for recurse calling this func if API fails
             current_page: Specify the page id to start the conversation from
             checkpoints: Boolean flag to enable/disable Checkpoint timer
@@ -355,7 +356,7 @@ class DialogflowConversation(ScrapiBase):
             if retries < MAX_RETRIES:
                 logging.error("retrying")
                 return self.reply(
-                    send_obj, restart=restart, raw=raw, retries=retries
+                    send_obj, restart=restart, retries=retries
                 )
             else:
                 logging.error("MAX_RETRIES exceeded")

--- a/src/dfcx_scrapi/core/conversation.py
+++ b/src/dfcx_scrapi/core/conversation.py
@@ -47,7 +47,7 @@ class DialogflowConversation(ScrapiBase):
         creds_path: str = None,
         creds_dict: Dict = None,
         creds=None,
-        agent_path: str = None,
+        agent_id: str = None,
         language_code: str = "en",
     ):
 
@@ -55,18 +55,20 @@ class DialogflowConversation(ScrapiBase):
             creds_path=creds_path,
             creds_dict=creds_dict,
             creds=creds,
-            agent_path=agent_path,
+            agent_id=agent_id,
         )
 
         logging.info(
             "create conversation with creds_path: %s | agent_path: %s",
             creds_path,
-            agent_path,
+            agent_id,
         )
 
-        # format: projects/*/locations/*/agents/*/
-        self.agent_path = agent_path or config["agent_path"]
+        if agent_id or config["agent_path"]:
+            self.agent_id = agent_id or config["agent_path"]
+
         self.language_code = language_code or config["language_code"]
+
         self.start_time = None
         self.query_result = None
         self.session_id = None
@@ -113,7 +115,7 @@ class DialogflowConversation(ScrapiBase):
 
     def _page_id_mapper(self):
         agent_pages_map = pd.DataFrame()
-        flow_map = self.flows.get_flows_map(agent_id=self.agent_path)
+        flow_map = self.flows.get_flows_map(agent_id=self.agent_id)
         for flow_id in flow_map.keys():
 
             page_map = self.pages.get_pages_map(flow_id=flow_id)
@@ -269,17 +271,17 @@ class DialogflowConversation(ScrapiBase):
         if restart:
             self.restart()
 
-        client_options = self._set_region(self.agent_path)
+        client_options = self._set_region(self.agent_id)
         session_client = SessionsClient(
             credentials=self.creds, client_options=client_options
         )
-        session_path = f"{self.agent_path}/sessions/{self.session_id}"
+        session_path = f"{self.agent_id}/sessions/{self.session_id}"
 
         custom_environment = self.agent_env.get("environment")
 
         if custom_environment:
             logging.info("req using env: %s", custom_environment)
-            session_path = f"{self.agent_path}/environments/"\
+            session_path = f"{self.agent_id}/environments/"\
             f"{custom_environment}/sessions/{self.session_id}"
 
         disable_webhook = self.agent_env.get("disable_webhook") or False

--- a/src/dfcx_scrapi/core/conversation.py
+++ b/src/dfcx_scrapi/core/conversation.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import logging
 import time
 import uuid

--- a/src/dfcx_scrapi/core/conversation.py
+++ b/src/dfcx_scrapi/core/conversation.py
@@ -31,12 +31,9 @@ from dfcx_scrapi.core.scrapi_base import ScrapiBase
 from dfcx_scrapi.core.flows import Flows
 from dfcx_scrapi.core.pages import Pages
 
-logger = logging
-
-logging.basicConfig(format="[dfcx] %(levelname)s:%(message)s", level=None)
+logging.basicConfig(format="[dfcx] %(levelname)s:%(message)s", level=logging.INFO)
 
 MAX_RETRIES = 3
-DEBUG_LEVEL = "info"
 
 
 class DialogflowConversation(ScrapiBase):
@@ -255,11 +252,13 @@ class DialogflowConversation(ScrapiBase):
         """
         text = send_obj.get("text")
         if not text:
-            logger.warning("trying to reply to empty message %s", send_obj)
+            logging.warning("trying to reply to empty message %s", send_obj)
 
-        if text and len(text) > 250:
-            logging.error("text is too long %s", text)
-            text = text[0:250]
+        if text and len(text) > 256:
+            logging.warning("Text input is too long. Truncating to 256 characters.")
+            text = text[0:256]
+            logging.warning(f"TRUNCATED TEXT: {text}")
+
 
         send_params = send_obj.get("params")
 

--- a/src/dfcx_scrapi/core/conversation.py
+++ b/src/dfcx_scrapi/core/conversation.py
@@ -253,7 +253,7 @@ class DialogflowConversation(ScrapiBase):
         """
         text = send_obj.get("text")
         if not text:
-            logging.warning("trying to reply to empty message %s", send_obj)
+            logging.warning(f"Input Text is empty. {send_obj}")
 
         if text and len(text) > 256:
             logging.warning("Text input is too long. Truncating to 256 characters.")

--- a/src/dfcx_scrapi/core/scrapi_base.py
+++ b/src/dfcx_scrapi/core/scrapi_base.py
@@ -38,7 +38,7 @@ class ScrapiBase:
         creds_dict: Dict[str,str] = None,
         creds: service_account.Credentials =None,
         scope=False,
-        agent_path=None,
+        agent_id=None,
     ):
 
         self.scopes = ScrapiBase.global_scopes
@@ -65,8 +65,8 @@ class ScrapiBase:
             self.creds = None
             self.token = None
 
-        if agent_path:
-            self.agent_path = agent_path
+        if agent_id:
+            self.agent_id = agent_id
 
     @staticmethod
     def _set_region(item_id):


### PR DESCRIPTION
* fixed truncate error; should be 256 instead of 250
* strings longer than 256 now log WARNING instead of ERROR
* fixed pd.append to use pd.concat now; pd.append is deprecated
* added new query_input types: `intent`, `dtmf`, `event`
* name space fix for agent_id
* lint fixes for style guide