### PR TITLE
Feature/detect param

### DIFF
--- a/src/dfcx_scrapi/core/conversation.py
+++ b/src/dfcx_scrapi/core/conversation.py
@@ -282,6 +282,7 @@ class DialogflowConversation(scrapi_base.ScrapiBase):
         results["detected_intent"][i] = intent or "NO_MATCH"
         results["confidence"][i] = confidence
         results["target_page"][i] = target_page
+        results["params"][i] = response["params"]
 
     def _get_intent_detection(self, test_set: pd.DataFrame):
         """Gets the results of a subset of Intent Detection tests.
@@ -308,6 +309,7 @@ class DialogflowConversation(scrapi_base.ScrapiBase):
             "detected_intent": [None] * len(utterances),
             "confidence": [None] * len(utterances),
             "target_page": [None] * len(utterances),
+            "params": [None] * len(utterances),
         }
         for i, (utterance, page_id) in enumerate(zip(utterances, page_ids)):
             threads[i] = Thread(
@@ -322,6 +324,7 @@ class DialogflowConversation(scrapi_base.ScrapiBase):
         test_set_mapped["detected_intent"] = results["detected_intent"]
         test_set_mapped["confidence"] = results["confidence"]
         test_set_mapped["target_page"] = results["target_page"]
+        test_set_mapped["params"] = results["params"]
         test_set_mapped = test_set_mapped.drop(columns=["page_id"])
 
         intent_detection = test_set_mapped.copy()

--- a/src/dfcx_scrapi/core/conversation.py
+++ b/src/dfcx_scrapi/core/conversation.py
@@ -583,9 +583,7 @@ class DialogflowConversation(scrapi_base.ScrapiBase):
         self.progress_bar(test_set.shape[0], test_set.shape[0])
         
         result = self._unpack_match(result)
-        column_order = ['flow_display_name', 'page_display_name', 'utterance', 
-            'match_type', 'detected_intent', 'parameters_set', 'confidence', 'target_page']
-        return result[column_order]
+        return result
 
     def _unpack_match(self, df: pd.DataFrame):
         """ Unpacks a 'match' column into four component columns.


### PR DESCRIPTION
This branch adds to the functionality of the conversation class so that `run_intent_detection()` also gets the results of filled parameters. 
End behavior is summarized thus: Original functionality returned a schema with the columns in normal text. This branch's functionality returns a schema with 2 additional columns (bold). 

flow_display_name
page_display_name
utterance
**match_type** : in {NO_MATCH, INTENT, PARAMETER_FILLING} 
detected_intent
**parameters_set** : a dictionary of parameter_name:value
confidence
target_page




