### PR TITLE
Update pandas append function for dataframes to pandas concat to suppress Pandas deprecation warning

### DIFF
--- a/src/dfcx_scrapi/core/entity_types.py
+++ b/src/dfcx_scrapi/core/entity_types.py
@@ -77,9 +77,7 @@ class EntityTypes(ScrapiBase):
                 entity_type_dict["entity_value"] = entity.value
                 for synonym in entity.synonyms:
                     entity_type_dict["synonyms"] = synonym
-                    main_df = main_df.append(
-                        entity_type_dict, ignore_index=True
-                    )
+                    main_df = pd.concat([main_df, entity_type_dict], ignore_index=True)
 
             return main_df
 
@@ -104,15 +102,11 @@ class EntityTypes(ScrapiBase):
                 entity_type_dict["entity_value"] = entity.value
                 for synonym in entity.synonyms:
                     entity_type_dict["synonyms"] = synonym
-                    main_df = main_df.append(
-                        entity_type_dict, ignore_index=True
-                    )
+                    main_df = pd.concat([main_df, entity_type_dict], ignore_index=True)
 
             for excluded_phrase in obj.excluded_phrases:
                 excluded_phrases_dict["excluded_phrase"] = excluded_phrase.value
-                excluded_phrases_df = excluded_phrases_df.append(
-                    excluded_phrases_dict, ignore_index=True
-                )
+                excluded_phrases_df = pd.concat([excluded_phrases_df, excluded_phrases_dict], ignore_index=True)
 
             return {
                 "entity_types": main_df, "excluded_phrases": excluded_phrases_df
@@ -152,7 +146,7 @@ class EntityTypes(ScrapiBase):
                 single_entity_df = self.entity_type_proto_to_dataframe(
                     obj, mode=mode
                 )
-                main_df = main_df.append(single_entity_df)
+                main_df = pd.concat([main_df, single_entity_df])
             main_df = main_df.sort_values(
                 ["display_name", "entity_value"])
             return main_df
@@ -167,10 +161,8 @@ class EntityTypes(ScrapiBase):
                 single_entity_dict = self.entity_type_proto_to_dataframe(
                     obj, mode=mode
                 )
-                main_df = main_df.append(single_entity_dict["entity_types"])
-                excluded_phrases_df = excluded_phrases_df.append(
-                    single_entity_dict["excluded_phrases"]
-                )
+                main_df = pd.concat([main_df, single_entity_dict["entity_types"]])
+                excluded_phrases_df = pd.concat([excluded_phrases_df, single_entity_dict["excluded_phrases"]])
             type_map = {
                 "auto_expansion_mode": bool,
                 "fuzzy_extraction": bool,

--- a/src/dfcx_scrapi/core/intents.py
+++ b/src/dfcx_scrapi/core/intents.py
@@ -110,7 +110,8 @@ class Intents(ScrapiBase):
                 for train_phrase in train_phrases:
                     part_id = 0
                     for part in train_phrase.parts:
-                        tp_df = tp_df.append(
+                        tp_df = pd.concat([
+                            tp_df,
                             pd.DataFrame(
                                 columns=[
                                     "display_name",
@@ -135,7 +136,7 @@ class Intents(ScrapiBase):
                                     ]
                                 ],
                             )
-                        )
+                        ])
                         part_id += 1
                     tp_id += 1
 
@@ -154,7 +155,8 @@ class Intents(ScrapiBase):
                 if len(params) > 0:
                     param_df = pd.DataFrame()
                     for param in params:
-                        param_df = param_df.append(
+                        param_df = pd.concat([
+                            param_df,
                             pd.DataFrame(
                                 columns=["display_name", "id", "entity_type"],
                                 data=[
@@ -165,7 +167,7 @@ class Intents(ScrapiBase):
                                     ]
                                 ],
                             )
-                        )
+                        ])
                     return {"phrases": phrases, "parameters": param_df}
 
                 else:
@@ -295,12 +297,14 @@ class Intents(ScrapiBase):
         ]
 
         updated_training_phrases_df = untouched.copy()
-        updated_training_phrases_df = updated_training_phrases_df.append(
+        updated_training_phrases_df = pd.concat([
+            updated_training_phrases_df,
             false_additions
-        )
-        updated_training_phrases_df = updated_training_phrases_df.append(
+        ])
+        updated_training_phrases_df = pd.concat([
+            updated_training_phrases_df,
             true_additions
-        )
+        ])
         updated_training_phrases_df = updated_training_phrases_df.drop(
             columns=["action"]
         )
@@ -321,7 +325,7 @@ class Intents(ScrapiBase):
                     axis=1,
                 ),
             )
-            actions_taken = actions_taken.append(true_additions)
+            actions_taken = pd.concat([actions_taken, true_additions])
 
         if false_additions.empty is False:
             false_additions.insert(len(false_additions.columns), "completed", 0)
@@ -338,7 +342,7 @@ class Intents(ScrapiBase):
                     axis=1,
                 ),
             )
-            actions_taken = actions_taken.append(false_additions)
+            actions_taken = pd.concat([actions_taken, false_additions])
 
         if true_deletions.empty is False:
             true_deletions.insert(len(true_deletions.columns), "completed", 1)
@@ -355,7 +359,7 @@ class Intents(ScrapiBase):
                     axis=1,
                 ),
             )
-            actions_taken = actions_taken.append(true_deletions)
+            actions_taken = pd.concat([actions_taken, true_deletions])
 
         if false_deletions.empty is False:
             false_deletions.insert(len(false_deletions.columns), "completed", 0)
@@ -372,7 +376,7 @@ class Intents(ScrapiBase):
                     axis=1,
                 ),
             )
-            actions_taken = actions_taken.append(false_deletions)
+            actions_taken = pd.concat([actions_taken, false_deletions])
 
         actionable_intents = list(
             set(actions_taken[actions_taken["completed"] == 1]["display_name"])
@@ -666,10 +670,11 @@ class Intents(ScrapiBase):
                 if (intent_subset) and (obj.display_name not in intent_subset):
                     continue
                 output = self.intent_proto_to_dataframe(obj, mode="advanced")
-                master_phrases = master_phrases.append(output["phrases"])
-                master_parameters = master_parameters.append(
+                master_phrases = pd.concat([master_phrases, output["phrases"]])
+                master_parameters = pd.concat([
+                    master_parameters,
                     output["parameters"]
-                )
+                ])
             return {"phrases": master_phrases, "parameters": master_parameters}
 
         else:

--- a/src/dfcx_scrapi/core/intents.py
+++ b/src/dfcx_scrapi/core/intents.py
@@ -654,7 +654,7 @@ class Intents(ScrapiBase):
                     continue
 
                 data_frame = self.intent_proto_to_dataframe(obj, mode=mode)
-                main_frame = main_frame.append(data_frame)
+                main_frame = pd.concat([main_frame, data_frame])
             main_frame = main_frame.sort_values(
                 ["display_name", "training_phrase"])
             return main_frame

--- a/src/dfcx_scrapi/core_ml/utterance_generator.py
+++ b/src/dfcx_scrapi/core_ml/utterance_generator.py
@@ -114,7 +114,7 @@ class UtteranceGenerator:
             iter_frame["synthetic_phrases"] = synthetic_phrases
             for col in origin_utterances.columns:
                 iter_frame[col] = row[col]
-            synthetic_phrases_df = synthetic_phrases_df.append(iter_frame)
+            synthetic_phrases_df = pd.concat([synthetic_phrases_df, iter_frame])
             ordered_cols = [
                 "id",
                 "synthetic_instances",

--- a/src/dfcx_scrapi/tools/dataframe_functions.py
+++ b/src/dfcx_scrapi/tools/dataframe_functions.py
@@ -143,8 +143,8 @@ class DataframeFunctions(ScrapiBase):
         for column in dataframe.columns:
             dataframe = dataframe.astype({column: type_map[column]})
             temp_data[column] = type_map[column]
-
-        dataframe = dataframe.append(temp_data, ignore_index=True)
+        
+        dataframe = pd.concat([dataframe, temp_data], ignore_index=True)
 
         return dataframe
 

--- a/src/dfcx_scrapi/tools/search_util.py
+++ b/src/dfcx_scrapi/tools/search_util.py
@@ -260,7 +260,8 @@ class SearchUtil(scrapi_base.ScrapiBase):
                 message.conversation_success.metadata
             )
             contents = (
-                {"conversation_success": c} if (message_format == "dict") else c
+                {"conversation_success": c} if (
+                    message_format == "dict") else c
             )
         elif "output_audio_text" in message:
             c = message.output_audio_text.text
@@ -321,7 +322,7 @@ class SearchUtil(scrapi_base.ScrapiBase):
                     ]
                 ],
             )
-            pages_dataframe = pages_dataframe.append(page_dataframe)
+            pages_dataframe = pd.concat([pages_dataframe, page_dataframe])
 
         return pages_dataframe
 
@@ -336,7 +337,8 @@ class SearchUtil(scrapi_base.ScrapiBase):
 
             for handler in flow_level_event_handlers:
                 flow_level_event_handlers_dataframe = (
-                    flow_level_event_handlers_dataframe.append(
+                    pd.concat([
+                        flow_level_event_handlers_dataframe,
                         pd.DataFrame(
                             columns=[
                                 "flow",
@@ -355,11 +357,12 @@ class SearchUtil(scrapi_base.ScrapiBase):
                                 ]
                             ],
                         )
-                    )
+                    ])
                 )
-                flow_event_handler_data = flow_event_handler_data.append(
+                flow_event_handler_data = pd.concat([
+                    flow_event_handler_data,
                     flow_level_event_handlers_dataframe
-                )
+                ])
 
         return flow_event_handler_data
 
@@ -375,7 +378,8 @@ class SearchUtil(scrapi_base.ScrapiBase):
                 page_level_event_handlers_dataframe = pd.DataFrame()
                 for handler in page_level_event_handlers:
                     page_level_event_handlers_dataframe = (
-                        page_level_event_handlers_dataframe.append(
+                        pd.concat([
+                            page_level_event_handlers_dataframe,
                             pd.DataFrame(
                                 columns=[
                                     "flow",
@@ -396,14 +400,13 @@ class SearchUtil(scrapi_base.ScrapiBase):
                                     ]
                                 ],
                             )
-                        )
+                        ])
                     )
 
-                page_level_event_handlers_all_dataframe = (
-                    page_level_event_handlers_all_dataframe.append(
-                        page_level_event_handlers_dataframe
-                    )
-                )
+                page_level_event_handlers_all_dataframe = pd.concat([
+                    page_level_event_handlers_all_dataframe,
+                    page_level_event_handlers_dataframe
+                ])
         return page_level_event_handlers_all_dataframe
 
     # Parameters - event handlers
@@ -420,7 +423,8 @@ class SearchUtil(scrapi_base.ScrapiBase):
                     )
                     param_lvl_event_df = pd.DataFrame()
                     for handler in parameter_event_handlers:
-                        param_lvl_event_df = param_lvl_event_df.append(
+                        param_lvl_event_df = pd.concat([
+                            param_lvl_event_df,
                             pd.DataFrame(
                                 columns=[
                                     "flow",
@@ -443,12 +447,11 @@ class SearchUtil(scrapi_base.ScrapiBase):
                                     ]
                                 ],
                             )
-                        )
-                    parameter_level_event_handlers_all_dataframe = (
-                        parameter_level_event_handlers_all_dataframe.append(
-                            param_lvl_event_df
-                        )
-                    )
+                        ])
+                    parameter_level_event_handlers_all_dataframe = pd.concat([
+                        parameter_level_event_handlers_all_dataframe,
+                        param_lvl_event_df
+                    ])
         return parameter_level_event_handlers_all_dataframe
 
     def find_list_parameters(self, agent_id):
@@ -503,7 +506,7 @@ class SearchUtil(scrapi_base.ScrapiBase):
                     columns=["resource_id", "condition", "route_id"],
                     data=[[page_id, route.condition, i]],
                 )
-                locator = locator.append(iter_frame)
+                locator = pd.concat([locator, iter_frame])
             i += 1
 
         return locator
@@ -528,7 +531,7 @@ class SearchUtil(scrapi_base.ScrapiBase):
                     columns=["resource_id", "condition", "route_id"],
                     data=[[flow_id, route.condition, i]],
                 )
-                locator = locator.append(iter_frame)
+                locator = pd.concat([locator, iter_frame])
             i += 1
 
         return locator
@@ -605,7 +608,7 @@ class SearchUtil(scrapi_base.ScrapiBase):
                 )
                 flow_search.insert(0, "resource_name", flow_name)
                 flow_search.insert(0, "resource_type", "flow")
-                locator = locator.append(flow_search)
+                locator = pd.concat([locator, flow_search])
             except ValueError:
                 logging.error(
                     "%s is not a valid flow_name for agent %s",
@@ -625,7 +628,7 @@ class SearchUtil(scrapi_base.ScrapiBase):
                     time.sleep(0.5)
                     page_search.insert(0, "resource_name", page)
                     page_search.insert(0, "resource_type", "page")
-                    locator = locator.append(page_search)
+                    locator = pd.concat([locator, page_search])
 
             return locator
 
@@ -641,7 +644,7 @@ class SearchUtil(scrapi_base.ScrapiBase):
                 )
                 flow_search.insert(0, "resource_name", flow)
                 flow_search.insert(0, "resource_type", "flow")
-                locator = locator.append(flow_search)
+                locator = pd.concat([locator, flow_search])
                 pages_map = self.pages.get_pages_map(
                     flow_id=flows_map[flow], reverse=True
                 )
@@ -652,7 +655,7 @@ class SearchUtil(scrapi_base.ScrapiBase):
                     time.sleep(0.5)
                     page_search.insert(0, "resource_name", page)
                     page_search.insert(0, "resource_type", "page")
-                    locator = locator.append(page_search)
+                    locator = pd.concat([locator, page_search])
             return locator
 
         # not found
@@ -690,7 +693,7 @@ class SearchUtil(scrapi_base.ScrapiBase):
             flow_scan = self._find_true_routes_flow_level(
                 flow_display_name, flow_map
             )
-            agent_results = agent_results.append(flow_scan)
+            agent_results = pd.concat([agent_results, flow_scan])
         return agent_results
 
     # Event handlers Main Function
@@ -810,7 +813,8 @@ class SearchUtil(scrapi_base.ScrapiBase):
         flow_df = self.get_flow_df(agent_id)
         page_df = self.get_page_df(flow_df)
 
-        route_group_df = self.get_route_group_df(page_df, list(flow_df.flow_id))
+        route_group_df = self.get_route_group_df(
+            page_df, list(flow_df.flow_id))
         route_df = SearchUtil.get_route_df(page_df, route_group_df)
         intent_map = self.intents.get_intents_map(agent_id)
         route_df.intent = route_df.intent.map(intent_map)
@@ -849,7 +853,8 @@ class SearchUtil(scrapi_base.ScrapiBase):
                 event_handler_df.rename(
                     columns={"trigger_fulfillment": "fulfillment"}
                 ),
-                route_df.rename(columns={"trigger_fulfillment": "fulfillment"}),
+                route_df.rename(
+                    columns={"trigger_fulfillment": "fulfillment"}),
                 param_initial_prompt_fulfillment_df.rename(
                     columns={"initial_prompt_fulfillment": "fulfillment"}
                 ),
@@ -904,30 +909,30 @@ class SearchUtil(scrapi_base.ScrapiBase):
             flow_df[["flow_name", "flow_id"]]
             .assign(page_obj=flow_df.flow_id.apply(self.pages.list_pages))
             .explode("page_obj", ignore_index=True)
-            )
+        )
 
         # Handle edge case where Flow exists without Pages
         page_df = page_df[~page_df.page_obj.isna()]
 
         page_df = page_df.assign(
-                page_name=lambda df: df.page_obj.apply(
-                    attrgetter("display_name")
-                ),
-                entry_fulfillment=lambda df: df.page_obj.apply(
-                    attrgetter("entry_fulfillment")
-                ),
-                parameters=lambda df: df.page_obj.apply(
-                    attrgetter("form.parameters")
-                ),
-                route_groups=lambda df: df.page_obj.apply(
-                    attrgetter("transition_route_groups")
-                ),
-                routes=lambda df: df.page_obj.apply(
-                    attrgetter("transition_routes")
-                ),
-                event_handlers=lambda df: df.page_obj.apply(
-                    attrgetter("event_handlers")
-                ))
+            page_name=lambda df: df.page_obj.apply(
+                attrgetter("display_name")
+            ),
+            entry_fulfillment=lambda df: df.page_obj.apply(
+                attrgetter("entry_fulfillment")
+            ),
+            parameters=lambda df: df.page_obj.apply(
+                attrgetter("form.parameters")
+            ),
+            route_groups=lambda df: df.page_obj.apply(
+                attrgetter("transition_route_groups")
+            ),
+            routes=lambda df: df.page_obj.apply(
+                attrgetter("transition_routes")
+            ),
+            event_handlers=lambda df: df.page_obj.apply(
+                attrgetter("event_handlers")
+            ))
 
         page_df = page_df.drop(columns="page_obj")
 

--- a/src/dfcx_scrapi/tools/semantic_clustering.py
+++ b/src/dfcx_scrapi/tools/semantic_clustering.py
@@ -220,7 +220,7 @@ class SemanticClustering:
                 )
                 clustered_this_round.insert(0, "eps", eps)
                 clustered_this_round.insert(0, "round", cluster_round)
-                clustered = clustered.append(clustered_this_round)
+                clustered = pd.concat([clustered, clustered_this_round])
                 unclustered = cluster_attempt.copy()[
                     cluster_attempt["cluster"] == -1
                 ]
@@ -247,9 +247,7 @@ class SemanticClustering:
             return clustered
 
         unclustered = unclustered.drop(columns="cluster")
-        clustered = clustered.sort_values(by="cluster", ascending=True).append(
-            unclustered
-        )
+        clustered = pd.concat([clustered.sort_values(by="cluster", ascending=True), unclustered])
 
         if cluster_round > max_rounds:
             logging.info("max clutering rounds reached before stop threshold")

--- a/src/dfcx_scrapi/tools/utterance_generator_util.py
+++ b/src/dfcx_scrapi/tools/utterance_generator_util.py
@@ -243,7 +243,7 @@ class UtteranceGeneratorUtils(scrapi_base.ScrapiBase):
             intent_set = self._generate_phrases_intent(
                 training_phrases_one_intent, synthetic_phrases_per_intent
             )
-            synthetic_dataset = synthetic_dataset.append(intent_set)
+            synthetic_dataset = pd.concat([synthetic_dataset, intent_set])
             i += 1
             self._progress_bar(i, len(intents_list))
 

--- a/src/dfcx_scrapi/tools/validation_util.py
+++ b/src/dfcx_scrapi/tools/validation_util.py
@@ -90,7 +90,7 @@ class ValidationUtil(ScrapiBase):
                         ]
                         i += 1
 
-                dataframe = dataframe.append(temp_df)
+                dataframe = pd.concat([dataframe, temp_df])
                 max_cols_old = 0
 
         return dataframe


### PR DESCRIPTION
Per Pandas v1.4.0's release notes ([source]), both `Dataframe.append` and `Series.append` are deprecated and the `FutureWarning` corresponding to this change mentions `append` will be removed; it recommends us to replace `append` with the `pandas.concat` method.

[source]: https://github.com/pandas-dev/pandas/blob/7a56966b4ce5e08c669a8effdcb3c74919567868/doc/source/whatsnew/v1.4.0.rst#deprecated-dataframeappend-and-seriesappend