### PR TITLE
Correctly set region using environment_path

### DIFF
--- a/src/dfcx_scrapi/core/experiments.py
+++ b/src/dfcx_scrapi/core/experiments.py
@@ -62,7 +62,7 @@ class ScrapiExperiments(ScrapiBase):
 
         request = types.experiment.ListExperimentsRequest()
         request.parent = environment_path
-        client_options = self._set_region(environment_id)
+        client_options = self._set_region(environment_path)
         client = services.experiments.ExperimentsClient(
             client_options=client_options, credentials=self.creds
         )


### PR DESCRIPTION
This fixes the error:
```
IndexError - path too short?
```