### PR TITLE
Adding a new match type for knowledge connector

### DIFF
--- a/src/dfcx_scrapi/core/conversation.py
+++ b/src/dfcx_scrapi/core/conversation.py
@@ -95,6 +95,7 @@ class DialogflowConversation(scrapi_base.ScrapiBase):
             4: "NO_MATCH",
             5: "NO_INPUT",
             6: "EVENT",
+            8: "KNOWLEDGE_CONNECTOR"
         }
 
         return match_type_map[match_type]


### PR DESCRIPTION
Without this match type, the NLU tests encounter the following error: 

```
/usr/local/lib/python3.8/dist-packages/proto/marshal/rules/enums.py:37: UserWarning: Unrecognized MatchType enum value: 8
  warnings.warn(
Exception in thread Thread-5690:
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dfcx_scrapi/core/conversation.py", line 287, in _get_reply_results
    response = self.reply(
  File "/usr/local/lib/python3.8/dist-packages/dfcx_scrapi/core/conversation.py", line 504, in reply
    reply["match_type"] = self._get_match_type_from_map(
  File "/usr/local/lib/python3.8/dist-packages/dfcx_scrapi/core/conversation.py", line 101, in _get_match_type_from_map
    return match_type_map[match_type]
KeyError: 8
```
