### PR TITLE
correct arg assignment for copy entity method

### DIFF
--- a/src/dfcx_scrapi/tools/copy_util.py
+++ b/src/dfcx_scrapi/tools/copy_util.py
@@ -628,7 +628,9 @@ class CopyUtil(ScrapiBase):
 
         # push to destination agent
         try:
-            self.entities.create_entity_type(destination_agent, entity_object)
+            self.entities.create_entity_type(
+                agent_id=destination_agent,
+                obj=entity_object)
             logging.info(
                 "Entity Type %s created successfully",
                 entity_object.display_name,


### PR DESCRIPTION
In a recent refactor of `core.entity_types.EntityTypes.create_entity_type` we added new args.  
The downstream call for `CopyUtil.copy_entity_type_to_agent` wasn't assigning the input args by name, and with the additional params they were misaligned.