### PR TITLE
Fix/set region

### DIFF
--- a/src/dfcx_scrapi/core/conversation.py
+++ b/src/dfcx_scrapi/core/conversation.py
@@ -87,13 +87,13 @@ class DialogflowConversation(scrapi_base.ScrapiBase):
         """
         # Config will take precedence if provided
         if config:
-          config_lang_code = config.get("language_code", None)
+            config_lang_code = config.get("language_code", None)
 
-          # We'll only return if it exist in the config on the off chance that
-          # some users have provided the langauge_code as a top level arg in
-          # addition to providing the config
-          if config_lang_code:
-              return config_lang_code
+            # We'll only return if it exist in the config on the off chance that
+            # some users have provided the langauge_code as a top level arg in
+            # addition to providing the config
+            if config_lang_code:
+                return config_lang_code
 
         return language_code
 
@@ -106,13 +106,13 @@ class DialogflowConversation(scrapi_base.ScrapiBase):
 
         # Config will take precedence if provided
         if config:
-          config_agent_path = config.get("agent_path", None)
+            config_agent_path = config.get("agent_path", None)
 
-          # We'll only return if it exist in the config on the off chance that
-          # some users have provided the agent_id as a top level arg in
-          # addition to providing the config
-          if config_agent_path:
-              return config_agent_path
+            # We'll only return if it exist in the config on the off chance that
+            # some users have provided the agent_id as a top level arg in
+            # addition to providing the config
+            if config_agent_path:
+                return config_agent_path
 
         elif input_agent_id:
             return input_agent_id

--- a/src/dfcx_scrapi/core/scrapi_base.py
+++ b/src/dfcx_scrapi/core/scrapi_base.py
@@ -72,7 +72,7 @@ class ScrapiBase:
             self.agent_id = agent_id
 
     @staticmethod
-    def _set_region(item_id):
+    def _set_region(resource_id: str):
         """Different regions have different API endpoints
 
         Args:
@@ -85,18 +85,27 @@ class ScrapiBase:
           if the location is "global"
         """
         try:
-            location = item_id.split("/")[3]
+            location = resource_id.split("/")[3]
         except IndexError as err:
-            logging.error("IndexError - path too short? %s", item_id)
+            logging.error("IndexError - path too short? %s", resource_id)
             raise err
+
+        project_id = resource_id.split("/")[1]
 
         if location != "global":
             api_endpoint = f"{location}-dialogflow.googleapis.com:443"
-            client_options = {"api_endpoint": api_endpoint}
+            client_options = {
+                "api_endpoint": api_endpoint,
+                "quota_project_id": project_id}
             return client_options
 
         else:
-            return None  # explicit None return when not required
+            api_endpoint = "dialogflow.googleapis.com:443"
+            client_options = {
+                "api_endpoint": api_endpoint,
+                "quota_project_id": project_id}
+
+            return client_options
 
     @staticmethod
     def pbuf_to_dict(pbuf):


### PR DESCRIPTION
- fix `_set_region` issue where it is not properly setting the `quota_project_id`
- add backwards compat refactor to `conversations.py` for the `agent_id` and `language_code` args
    - this will allow users to instantiate the class without providing the above args if necessary
    - specifically implemented for use cases where the class is being instantiated prior to the `agent_id` being known