### PR TITLE
Feature/api call counter

### DIFF
--- a/src/dfcx_scrapi/core/agents.py
+++ b/src/dfcx_scrapi/core/agents.py
@@ -53,6 +53,7 @@ class Agents(scrapi_base.ScrapiBase):
             self.agent_id = agent_id
             self.client_options = self._set_region(agent_id)
 
+    @scrapi_base.api_call_counter_decorator
     def _build_list_agents_client_request(self, location_id):
         """Builds the List Agents Request object."""
 
@@ -125,6 +126,7 @@ class Agents(scrapi_base.ScrapiBase):
 
         return agents
 
+    @scrapi_base.api_call_counter_decorator
     def get_agent(self, agent_id: str) -> types.Agent:
         """Retrieves a single CX Agent resource object.
 
@@ -216,6 +218,7 @@ class Agents(scrapi_base.ScrapiBase):
 
         return matched_agent
 
+    @scrapi_base.api_call_counter_decorator
     def create_agent(
         self,
         project_id: str,
@@ -273,6 +276,7 @@ class Agents(scrapi_base.ScrapiBase):
         return response
 
 
+    @scrapi_base.api_call_counter_decorator
     def validate_agent(
         self,
         agent_id: str = None,
@@ -309,6 +313,7 @@ class Agents(scrapi_base.ScrapiBase):
         return val_dict
 
 
+    @scrapi_base.api_call_counter_decorator
     def get_validation_result(
         self,
         agent_id: str = None,
@@ -354,6 +359,7 @@ class Agents(scrapi_base.ScrapiBase):
         return val_results_dict
 
 
+    @scrapi_base.api_call_counter_decorator
     def export_agent(
         self,
         agent_id: str,
@@ -402,6 +408,7 @@ class Agents(scrapi_base.ScrapiBase):
         return response.operation.name
 
 
+    @scrapi_base.api_call_counter_decorator
     def restore_agent(self, agent_id: str, gcs_bucket_uri: str) -> str:
         """Restores a CX agent from a gcs_bucket location.
 
@@ -433,6 +440,7 @@ class Agents(scrapi_base.ScrapiBase):
 
         return response.operation.name
 
+    @scrapi_base.api_call_counter_decorator
     def update_agent(
         self, agent_id: str, obj: types.Agent = None, **kwargs
     ) -> types.Agent:
@@ -470,6 +478,7 @@ class Agents(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def delete_agent(self, agent_id: str) -> str:
         """Deletes the specified Dialogflow CX Agent.
 

--- a/src/dfcx_scrapi/core/agents.py
+++ b/src/dfcx_scrapi/core/agents.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import logging
-from typing import Dict, List, Tuple
+from typing import Dict, List
 from google.cloud.dialogflowcx_v3beta1 import services
 from google.cloud.dialogflowcx_v3beta1 import types
 from google.protobuf import field_mask_pb2
@@ -180,14 +180,12 @@ class Agents(scrapi_base.ScrapiBase):
         """
 
         if location_id:
-            agent_list = self.list_agents(
-                location=location_id
-                )
+            agent_list = self._list_agents_client_request(location_id)
 
         elif region:
-            agent_list = self.list_agents(
-                location=f"projects/{project_id}/locations/{region}"
-            )
+            agent_list = self._list_agents_client_request(
+                f"projects/{project_id}/locations/{region}"
+                )
         else:
             agent_list = self.list_agents(project_id=project_id)
 

--- a/src/dfcx_scrapi/core/changelogs.py
+++ b/src/dfcx_scrapi/core/changelogs.py
@@ -23,7 +23,7 @@ import pandas as pd
 
 from google.cloud.dialogflowcx_v3beta1 import services
 from google.cloud.dialogflowcx_v3beta1 import types
-from dfcx_scrapi.core.scrapi_base import ScrapiBase
+from dfcx_scrapi.core import scrapi_base
 
 # logging config
 logging.basicConfig(
@@ -33,7 +33,7 @@ logging.basicConfig(
 )
 
 
-class Changelogs(ScrapiBase):
+class Changelogs(scrapi_base.ScrapiBase):
     """Tools class that contains methods to support Change History feature."""
 
     def __init__(
@@ -76,6 +76,7 @@ class Changelogs(ScrapiBase):
         else:
             return True
 
+    @scrapi_base.api_call_counter_decorator
     def list_changelogs(self, agent_id: str = None, **kwargs):
         """Lists all Change History logs for a CX Agent.
 
@@ -147,6 +148,7 @@ class Changelogs(ScrapiBase):
 
         return changelogs
 
+    @scrapi_base.api_call_counter_decorator
     def get_changelog(self, changelog_id: str):
         """Get a single changelog resource object.
 

--- a/src/dfcx_scrapi/core/conversation.py
+++ b/src/dfcx_scrapi/core/conversation.py
@@ -395,6 +395,7 @@ class DialogflowConversation(scrapi_base.ScrapiBase):
             if msg:
                 print(f"{duration:0.2f}s {msg}")
 
+    @scrapi_base.api_call_counter_decorator
     def reply(
         self,
         send_obj: Dict[str, str],

--- a/src/dfcx_scrapi/core/entity_types.py
+++ b/src/dfcx_scrapi/core/entity_types.py
@@ -22,7 +22,7 @@ from google.cloud.dialogflowcx_v3beta1 import services
 from google.cloud.dialogflowcx_v3beta1 import types
 from google.protobuf import field_mask_pb2
 
-from dfcx_scrapi.core.scrapi_base import ScrapiBase
+from dfcx_scrapi.core import scrapi_base
 
 # logging config
 logging.basicConfig(
@@ -32,7 +32,7 @@ logging.basicConfig(
 )
 
 
-class EntityTypes(ScrapiBase):
+class EntityTypes(scrapi_base.ScrapiBase):
     """Core Class for CX Entity Type Resource functions."""
 
     def __init__(
@@ -243,6 +243,7 @@ class EntityTypes(ScrapiBase):
 
         return entities_dict
 
+    @scrapi_base.api_call_counter_decorator
     def list_entity_types(self, agent_id: str = None):
         """Returns a list of Entity Type objects.
 
@@ -272,6 +273,7 @@ class EntityTypes(ScrapiBase):
 
         return entities
 
+    @scrapi_base.api_call_counter_decorator
     def get_entity_type(self, entity_id: str = None):
         """Returns a single Entity Type object.
 
@@ -292,6 +294,7 @@ class EntityTypes(ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def create_entity_type(
         self,
         agent_id: str = None,
@@ -353,6 +356,7 @@ class EntityTypes(ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def update_entity_type(
         self,
         entity_type_id: str = None,
@@ -407,6 +411,7 @@ class EntityTypes(ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def delete_entity_type(self, entity_id: str = None, obj=None) -> None:
         """Deletes a single Entity Type resouce object.
 

--- a/src/dfcx_scrapi/core/environments.py
+++ b/src/dfcx_scrapi/core/environments.py
@@ -38,7 +38,7 @@ class Environments(scrapi_base.ScrapiBase):
     def __init__(
         self,
         creds_path: str = None,
-        creds_dict: Dict[str,str] = None,
+        creds_dict: Dict[str, str] = None,
         creds: service_account.Credentials = None,
         agent_id: str = None,
     ):
@@ -129,7 +129,8 @@ class Environments(scrapi_base.ScrapiBase):
 
         return environments_dict
 
-    def list_environments(self, agent_id:str=None):
+    @scrapi_base.api_call_counter_decorator
+    def list_environments(self, agent_id: str = None):
         """List all Versions for a given Flow"""
 
         if not agent_id:
@@ -152,9 +153,10 @@ class Environments(scrapi_base.ScrapiBase):
 
         return environments
 
+    @scrapi_base.api_call_counter_decorator
     def get_environment(
         self,
-        environment_id:str) -> types.environment.Environment:
+        environment_id: str) -> types.environment.Environment:
         """Get Environment object for specified environment ID.
 
         Args:
@@ -178,8 +180,8 @@ class Environments(scrapi_base.ScrapiBase):
 
     def get_environment_by_display_name(
         self,
-        display_name:str,
-        agent_id:str) -> types.environment.Environment:
+        display_name: str,
+        agent_id: str) -> types.environment.Environment:
         """Get Environment object for specific environment by its display name.
 
         Args:
@@ -201,10 +203,11 @@ class Environments(scrapi_base.ScrapiBase):
 
         return result
 
+    @scrapi_base.api_call_counter_decorator
     def create_environment(
         self,
-        environment:types.environment.Environment,
-        agent_id:str=None):
+        environment: types.environment.Environment,
+        agent_id: str = None):
         """Create a new environment for a specified agent.
         Args:
           environment: The environment to create.
@@ -235,10 +238,10 @@ class Environments(scrapi_base.ScrapiBase):
 
     def create_environment_by_display_name(
         self,
-        display_name:str,
-        version_configs:List[Tuple[str,str]],
-        description:str=None,
-        agent_id:str=None):
+        display_name: str,
+        version_configs: List[Tuple[str, str]],
+        description: str = None,
+        agent_id: str = None):
         """Create a new environment for a specified agent.
         Args:
           display_name: The display name of the Environment to create
@@ -286,10 +289,11 @@ class Environments(scrapi_base.ScrapiBase):
         return response
 
 
+    @scrapi_base.api_call_counter_decorator
     def update_environment(
         self,
         environment_id: str,
-        environment_obj:types.Environment = None,
+        environment_obj: types.Environment = None,
         **kwargs):
         """Update an existing environment for a specified agent.
 
@@ -330,7 +334,8 @@ class Environments(scrapi_base.ScrapiBase):
         return response
 
 
-    def delete_environment(self, environment_id:str):
+    @scrapi_base.api_call_counter_decorator
+    def delete_environment(self, environment_id: str):
         """Delete a specified environment.
 
         Args:
@@ -350,10 +355,11 @@ class Environments(scrapi_base.ScrapiBase):
         client.delete_environment(request)
 
 
+    @scrapi_base.api_call_counter_decorator
     def deploy_flow_to_environment(
         self,
-        environment_id:str,
-        flow_version:str):
+        environment_id: str,
+        flow_version: str):
         """Deploys a flow to the specified environment.
 
          Args:
@@ -382,9 +388,10 @@ class Environments(scrapi_base.ScrapiBase):
         return response
 
 
+    @scrapi_base.api_call_counter_decorator
     def lookup_environment_history(
         self,
-        environment_id:str) -> List[types.Environment]:
+        environment_id: str) -> List[types.Environment]:
         """Looks up the history of the specified environment.
 
         Args:
@@ -413,7 +420,8 @@ class Environments(scrapi_base.ScrapiBase):
 
         return history
 
-    def list_continuous_test_results(self, environment_id:str):
+    @scrapi_base.api_call_counter_decorator
+    def list_continuous_test_results(self, environment_id: str):
         """Fetches a list of continuous test results for a given environment.
 
         Args:

--- a/src/dfcx_scrapi/core/experiments.py
+++ b/src/dfcx_scrapi/core/experiments.py
@@ -19,7 +19,7 @@ import logging
 from typing import Dict
 from google.cloud.dialogflowcx_v3beta1 import services
 from google.cloud.dialogflowcx_v3beta1 import types
-from dfcx_scrapi.core.scrapi_base import ScrapiBase
+from dfcx_scrapi.core import scrapi_base
 
 # logging config
 logging.basicConfig(
@@ -34,7 +34,7 @@ SCOPES = [
 ]
 
 
-class ScrapiExperiments(ScrapiBase):
+class ScrapiExperiments(scrapi_base.ScrapiBase):
     """Wrapper for working with Experiments"""
 
     def __init__(
@@ -55,7 +55,8 @@ class ScrapiExperiments(ScrapiBase):
 
         logging.info("created %s", self.agent_id)
 
-    def list_experiments(self, environment_id=None):
+    @scrapi_base.api_call_counter_decorator
+    def list_experiments(self, environment_id: str = None):
         """List out experiments.
 
         Args:
@@ -75,7 +76,7 @@ class ScrapiExperiments(ScrapiBase):
             client_options=client_options, credentials=self.creds
         )
         response = client.list_experiments(request)
-        blob = ScrapiBase.cx_object_to_json(response)
+        blob = scrapi_base.ScrapiBase.cx_object_to_json(response)
 
         if len(blob) < 1:
             logging.warning(

--- a/src/dfcx_scrapi/core/flows.py
+++ b/src/dfcx_scrapi/core/flows.py
@@ -129,6 +129,7 @@ class Flows(scrapi_base.ScrapiBase):
 
         return flows_dict
 
+    @scrapi_base.api_call_counter_decorator
     def train_flow(self, flow_id: str) -> str:
         """Trains the specified flow.
 
@@ -155,6 +156,7 @@ class Flows(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def list_flows(self, agent_id: str) -> List[types.Flow]:
         """Get a List of all Flows in the current Agent.
 
@@ -208,6 +210,7 @@ class Flows(scrapi_base.ScrapiBase):
 
         return flow
 
+    @scrapi_base.api_call_counter_decorator
     def get_flow(self, flow_id: str) -> types.Flow:
         """Get a single CX Flow object.
 
@@ -226,6 +229,7 @@ class Flows(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def create_flow(
         self,
         agent_id: str,
@@ -274,6 +278,7 @@ class Flows(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def update_flow(
         self, flow_id: str, obj: types.Flow = None, **kwargs
     ) -> types.Flow:
@@ -325,6 +330,7 @@ class Flows(scrapi_base.ScrapiBase):
             setattr(current_settings, key, value)
         self.update_flow(flow_id=flow_id, nlu_settings=current_settings)
 
+    @scrapi_base.api_call_counter_decorator
     def export_flow(
         self, flow_id: str, gcs_path: str, ref_flows: bool = True
     ) -> Dict[str, str]:
@@ -355,6 +361,7 @@ class Flows(scrapi_base.ScrapiBase):
 
         return response.result()
 
+    @scrapi_base.api_call_counter_decorator
     def export_flow_inline(self, flow_id: str, ref_flows: bool = True) -> bytes:
         """Export a Flow, returning uncompressed raw byte content for flow.
 
@@ -377,6 +384,7 @@ class Flows(scrapi_base.ScrapiBase):
 
         return (response.result()).flow_content
 
+    @scrapi_base.api_call_counter_decorator
     def import_flow(
         self,
         agent_id: str,
@@ -425,6 +433,7 @@ class Flows(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def delete_flow(self, flow_id: str, force: bool = False):
         """Deletes a single CX Flow Object resource.
 

--- a/src/dfcx_scrapi/core/intents.py
+++ b/src/dfcx_scrapi/core/intents.py
@@ -23,7 +23,7 @@ from google.cloud.dialogflowcx_v3beta1 import services
 from google.cloud.dialogflowcx_v3beta1 import types
 from google.protobuf import field_mask_pb2
 
-from dfcx_scrapi.core.scrapi_base import ScrapiBase
+from dfcx_scrapi.core import scrapi_base
 
 # logging config
 logging.basicConfig(
@@ -33,7 +33,7 @@ logging.basicConfig(
 )
 
 
-class Intents(ScrapiBase):
+class Intents(scrapi_base.ScrapiBase):
     """Core Class for CX Intent Resource functions."""
 
     def __init__(
@@ -409,6 +409,7 @@ class Intents(ScrapiBase):
 
         return intents_dict
 
+    @scrapi_base.api_call_counter_decorator
     def list_intents(
         self,
         agent_id: str = None,
@@ -445,6 +446,7 @@ class Intents(ScrapiBase):
 
         return intents
 
+    @scrapi_base.api_call_counter_decorator
     def get_intent(
         self,
         intent_id: str = None,
@@ -477,6 +479,7 @@ class Intents(ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def create_intent(
         self,
         agent_id: str,
@@ -531,6 +534,7 @@ class Intents(ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def update_intent(
         self,
         intent_id: str = None,
@@ -582,6 +586,7 @@ class Intents(ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def delete_intent(self, intent_id: str, obj: types.Intent = None) -> None:
         """Deletes an intent by Intent ID.
 

--- a/src/dfcx_scrapi/core/operations.py
+++ b/src/dfcx_scrapi/core/operations.py
@@ -16,8 +16,10 @@
 
 import logging
 from typing import Dict
+
 from google.api_core import operations_v1, grpc_helpers
-from dfcx_scrapi.core.scrapi_base import ScrapiBase
+
+from dfcx_scrapi.core import scrapi_base
 
 # logging config
 logging.basicConfig(
@@ -26,7 +28,7 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 
-class Operations(ScrapiBase):
+class Operations(scrapi_base.ScrapiBase):
     """Core class for Operations functions, primarily used to
     extract LRO information on long running jobs for CX.
     """
@@ -45,6 +47,7 @@ class Operations(ScrapiBase):
             scope=scope
         )
 
+    @scrapi_base.api_call_counter_decorator
     def get_lro(self, lro: str):
         """Used to retrieve the status of LROs for Dialogflow CX.
 

--- a/src/dfcx_scrapi/core/pages.py
+++ b/src/dfcx_scrapi/core/pages.py
@@ -230,7 +230,7 @@ class Pages(scrapi_base.ScrapiBase):
         return response
 
     @scrapi_base.api_call_counter_decorator
-    def delete_page(self, page_id: str = None) -> str:
+    def delete_page(self, page_id: str = None, force: bool = False) -> str:
         """Deletes the specified Page.
 
         Args:

--- a/src/dfcx_scrapi/core/pages.py
+++ b/src/dfcx_scrapi/core/pages.py
@@ -237,6 +237,9 @@ class Pages(scrapi_base.ScrapiBase):
           page_id: CX Page ID string in the following Format:
             ``projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/
               flows/<Flow ID>/pages/<Page ID>``
+          force: (Optional) This field has no effect for pages with no incoming
+            transitions. If set to True, Dialogflow will remove the page,
+            as well as any transitions to the page.
 
         Returns:
           String "Page `{page_id}` successfully deleted."
@@ -245,6 +248,7 @@ class Pages(scrapi_base.ScrapiBase):
         client = pages.PagesClient(
             credentials=self.creds, client_options=client_options
         )
-        client.delete_page(name=page_id)
+        req = gcdc_page.DeletePageRequest(name=page_id, force=force)
+        client.delete_page(request=req)
 
         return f"Page `{page_id}` successfully deleted."

--- a/src/dfcx_scrapi/core/pages.py
+++ b/src/dfcx_scrapi/core/pages.py
@@ -112,6 +112,7 @@ class Pages(scrapi_base.ScrapiBase):
 
         return pages_dict
 
+    @scrapi_base.api_call_counter_decorator
     def list_pages(self, flow_id: str = None) -> List[gcdc_page.Page]:
         """Get a List of all pages for the specified Flow ID.
 
@@ -137,6 +138,7 @@ class Pages(scrapi_base.ScrapiBase):
 
         return cx_pages
 
+    @scrapi_base.api_call_counter_decorator
     def get_page(self, page_id: str = None) -> gcdc_page.Page:
         """Get a single CX Page object based on the provided Page ID.
 
@@ -158,6 +160,7 @@ class Pages(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def create_page(
         self, flow_id: str = None, obj: gcdc_page.Page = None, **kwargs
     ) -> gcdc_page.Page:
@@ -191,6 +194,7 @@ class Pages(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def update_page(
         self, page_id: str = None, obj: gcdc_page.Page = None, **kwargs
     ) -> gcdc_page.Page:
@@ -225,6 +229,7 @@ class Pages(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def delete_page(self, page_id: str = None) -> str:
         """Deletes the specified Page.
 

--- a/src/dfcx_scrapi/core/project.py
+++ b/src/dfcx_scrapi/core/project.py
@@ -18,7 +18,7 @@ import logging
 import time
 from typing import Dict
 
-from dfcx_scrapi.core.scrapi_base import ScrapiBase
+from dfcx_scrapi.core import scrapi_base
 from dfcx_scrapi.core.agents import Agents
 
 # logging config
@@ -29,7 +29,7 @@ logging.basicConfig(
 )
 
 
-class Project(ScrapiBase):
+class Project(scrapi_base.ScrapiBase):
     """Top Level class representing the Project level resources
     when working on a Dialogflow CX project. This Class will allow you to
     extract information about your GCP project as a whole in relation to

--- a/src/dfcx_scrapi/core/scrapi_base.py
+++ b/src/dfcx_scrapi/core/scrapi_base.py
@@ -276,6 +276,18 @@ class ScrapiBase:
 
         return new_dict
 
+    def api_calls_count(self) -> int:
+        """Show the total number of API calls for this resource.
+
+        Returns:
+            Total calls to the API so far.
+        """
+        return sum(
+            getattr(getattr(self, f), "api_call_count", 0)
+            for f in dir(self)
+            if callable(getattr(self, f))
+        )
+
 
 def api_call_counter_decorator(func):
     """Counts the number of API calls for the function `func`."""

--- a/src/dfcx_scrapi/core/scrapi_base.py
+++ b/src/dfcx_scrapi/core/scrapi_base.py
@@ -275,3 +275,16 @@ class ScrapiBase:
             new_dict[k] = v
 
         return new_dict
+
+
+def api_call_counter_decorator(func):
+    """Counts the number of API calls for the function `func`."""
+
+    def wrapper(*args, **kwargs):
+        wrapper.api_call_count += 1
+        return func(*args, **kwargs)
+
+    wrapper.api_call_count = 0
+    wrapper.__name__ = func.__name__
+
+    return wrapper

--- a/src/dfcx_scrapi/core/scrapi_base.py
+++ b/src/dfcx_scrapi/core/scrapi_base.py
@@ -276,17 +276,28 @@ class ScrapiBase:
 
         return new_dict
 
-    def api_calls_count(self) -> int:
+    def api_calls_count_dict(self) -> Dict[str, int]:
+        """The number of API calls corresponding to each method.
+
+        Returns:
+          A dictionary with keys as the method names
+          and values as number of calls.
+        """
+        out_dict = {}
+        for attr_name in dir(self):
+            attr = getattr(self, attr_name)
+            if callable(attr) and hasattr(attr, "api_call_count"):
+                out_dict[attr_name] = getattr(attr, "api_call_count")
+
+        return out_dict
+
+    def total_api_calls(self) -> int:
         """Show the total number of API calls for this resource.
 
         Returns:
-            Total calls to the API so far.
+          Total calls to the API so far as an int.
         """
-        return sum(
-            getattr(getattr(self, f), "api_call_count", 0)
-            for f in dir(self)
-            if callable(getattr(self, f))
-        )
+        return sum(self.api_calls_count_dict().values())
 
 
 def api_call_counter_decorator(func):

--- a/src/dfcx_scrapi/core/security_settings.py
+++ b/src/dfcx_scrapi/core/security_settings.py
@@ -54,6 +54,7 @@ class SecuritySettings(scrapi_base.ScrapiBase):
         self.ss_service = services.security_settings_service
         self.ss_types = types.security_settings
 
+    @scrapi_base.api_call_counter_decorator
     def list_security_settings(self, location_id: str):
         """List Security Settings for a given Project and Region.
 
@@ -83,6 +84,7 @@ class SecuritySettings(scrapi_base.ScrapiBase):
         return security_settings
 
 
+    @scrapi_base.api_call_counter_decorator
     def get_security_settings(self, security_setting_id: str):
         """Get specified CCAI Security Setting.
 
@@ -107,6 +109,7 @@ class SecuritySettings(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def create_security_settings(
         self,
         location_id: str,
@@ -158,6 +161,7 @@ class SecuritySettings(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def update_security_settings(self, security_setting_id: str, **kwargs):
         """Update specified CCAI Security Setting.
 
@@ -192,6 +196,7 @@ class SecuritySettings(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def delete_security_settings(self, security_setting_id: str):
         """Delete the specified CCAI Security Setting.
 

--- a/src/dfcx_scrapi/core/session_entity_types.py
+++ b/src/dfcx_scrapi/core/session_entity_types.py
@@ -193,6 +193,7 @@ class SessionEntityTypes(scrapi_base.ScrapiBase):
 
         return st
 
+    @scrapi_base.api_call_counter_decorator
     def list_session_entity_types(
         self, session_id: str, environment_id: str = None
     ) -> List[types.SessionEntityType]:
@@ -236,6 +237,7 @@ class SessionEntityTypes(scrapi_base.ScrapiBase):
 
         return session_entities
 
+    @scrapi_base.api_call_counter_decorator
     def get_session_entity_type(
         self, session_entity_type_id: str, environment_id: str = None
     ) -> types.SessionEntityType:
@@ -272,6 +274,7 @@ class SessionEntityTypes(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def create_session_entity_type(
         self, session_id: str, session_entity_type: types.SessionEntityType
     ) -> types.SessionEntityType:
@@ -299,6 +302,7 @@ class SessionEntityTypes(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def update_session_entity_type(
         self,
         session_entity_type_id: str,
@@ -361,6 +365,7 @@ class SessionEntityTypes(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def delete_session_entity_type(
         self, session_entity_type_id: str, environment_id: str = None
     ) -> str:

--- a/src/dfcx_scrapi/core/sessions.py
+++ b/src/dfcx_scrapi/core/sessions.py
@@ -142,7 +142,6 @@ class Sessions(scrapi_base.ScrapiBase):
 
             response = session_client.detect_intent(request=request)
 
-        # TODO (miladt): Need to be refactored for api decorator to work
         for text in conversation:
             text_input = types.session.TextInput(text=text)
             query_input = types.session.QueryInput(
@@ -226,7 +225,6 @@ class Sessions(scrapi_base.ScrapiBase):
 
         logging.info(f"Starting Session ID {session_id}")
 
-        # TODO (miladt): Extra response in if?
         if parameters:
             query_params = types.session.QueryParameters(parameters=parameters)
 
@@ -251,7 +249,6 @@ class Sessions(scrapi_base.ScrapiBase):
 
         return query_result
 
-    @scrapi_base.api_call_counter_decorator
     def preset_parameters(
         self, agent_id: str = None, session_id: str = None, parameters=None
     ):

--- a/src/dfcx_scrapi/core/sessions.py
+++ b/src/dfcx_scrapi/core/sessions.py
@@ -20,7 +20,7 @@ from typing import Dict, List
 from google.cloud.dialogflowcx_v3beta1 import services
 from google.cloud.dialogflowcx_v3beta1 import types
 
-from dfcx_scrapi.core.scrapi_base import ScrapiBase
+from dfcx_scrapi.core import scrapi_base
 
 # logging config
 logging.basicConfig(
@@ -29,7 +29,7 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 
-class Sessions(ScrapiBase):
+class Sessions(scrapi_base.ScrapiBase):
     """Core Class for CX Session Resource functions."""
 
     def __init__(
@@ -142,6 +142,7 @@ class Sessions(ScrapiBase):
 
             response = session_client.detect_intent(request=request)
 
+        # TODO (miladt): Need to be refactored for api decorator to work
         for text in conversation:
             text_input = types.session.TextInput(text=text)
             query_input = types.session.QueryInput(
@@ -225,6 +226,7 @@ class Sessions(ScrapiBase):
 
         logging.info(f"Starting Session ID {session_id}")
 
+        # TODO (miladt): Extra response in if?
         if parameters:
             query_params = types.session.QueryParameters(parameters=parameters)
 
@@ -249,6 +251,7 @@ class Sessions(ScrapiBase):
 
         return query_result
 
+    @scrapi_base.api_call_counter_decorator
     def preset_parameters(
         self, agent_id: str = None, session_id: str = None, parameters=None
     ):

--- a/src/dfcx_scrapi/core/test_cases.py
+++ b/src/dfcx_scrapi/core/test_cases.py
@@ -22,7 +22,7 @@ from google.cloud.dialogflowcx_v3beta1 import services
 from google.cloud.dialogflowcx_v3beta1 import types
 from google.protobuf import field_mask_pb2
 
-from dfcx_scrapi.core.scrapi_base import ScrapiBase
+from dfcx_scrapi.core import scrapi_base
 
 # logging config
 logging.basicConfig(
@@ -32,7 +32,7 @@ logging.basicConfig(
 )
 
 
-class TestCases(ScrapiBase):
+class TestCases(scrapi_base.ScrapiBase):
     """Core Class for CX Test Cases."""
 
     def __init__(
@@ -59,6 +59,7 @@ class TestCases(ScrapiBase):
             self.test_case_id = test_case_id
             self.client_options = self._set_region(self.test_case_id)
 
+    @scrapi_base.api_call_counter_decorator
     def list_test_cases(self, agent_id: str = None):
         """List test cases from an agent.
 
@@ -91,6 +92,7 @@ class TestCases(ScrapiBase):
 
         return test_cases
 
+    @scrapi_base.api_call_counter_decorator
     def export_test_cases(
         self,
         gcs_uri: str,
@@ -137,6 +139,7 @@ class TestCases(ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def create_test_case(self, test_case: types.TestCase, agent_id: str = None):
         """Create a new Test Case in the specified CX Agent.
 
@@ -162,6 +165,7 @@ class TestCases(ScrapiBase):
         response = client.create_test_case(request)
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def get_test_case(self, test_case_id: str):
         """Get test case object from CX Agent.
 
@@ -184,6 +188,7 @@ class TestCases(ScrapiBase):
         response = client.get_test_case(request)
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def import_test_cases(self, gcs_uri: str, agent_id: str = None):
         """Import test cases from cloud storage.
 
@@ -212,6 +217,7 @@ class TestCases(ScrapiBase):
         result = response.result()
         return result
 
+    @scrapi_base.api_call_counter_decorator
     def batch_delete_test_cases(
         self,
         test_case_ids: List[str],
@@ -242,6 +248,7 @@ class TestCases(ScrapiBase):
         )
         client.batch_delete_test_cases(request)
 
+    @scrapi_base.api_call_counter_decorator
     def list_test_case_results(self, test_case_id: str):
         """List the results from a specific Test Case.
 
@@ -272,6 +279,7 @@ class TestCases(ScrapiBase):
 
         return test_case_results
 
+    @scrapi_base.api_call_counter_decorator
     def batch_run_test_cases(
         self,
         test_cases: List[str],
@@ -309,6 +317,7 @@ class TestCases(ScrapiBase):
         results = response.result()
         return results
 
+    @scrapi_base.api_call_counter_decorator
     def update_test_case(
         self,
         test_case_id: str = None,
@@ -348,6 +357,7 @@ class TestCases(ScrapiBase):
         response = client.update_test_case(request)
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def run_test_case(self, test_case_id: str, environment: str = None):
         """Run test case and get result for a specified test case.
 
@@ -375,6 +385,7 @@ class TestCases(ScrapiBase):
         results = response.result()
         return results
 
+    @scrapi_base.api_call_counter_decorator
     def get_test_case_result(self, test_case_result_id: str):
         """Get test case result for a specified run on a specified test case.
 
@@ -396,6 +407,7 @@ class TestCases(ScrapiBase):
         response = client.get_test_case_result(request)
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def calculate_coverage(self, coverage_type: int, agent_id: str = None):
         """Calculate coverage of different resources in the test case set.
 

--- a/src/dfcx_scrapi/core/transition_route_groups.py
+++ b/src/dfcx_scrapi/core/transition_route_groups.py
@@ -134,6 +134,7 @@ class TransitionRouteGroups(scrapi_base.ScrapiBase):
 
         return pages_dict
 
+    @scrapi_base.api_call_counter_decorator
     def list_transition_route_groups(self, flow_id: str = None):
         """Exports List of all Route Groups in the specified CX Flow ID.
 
@@ -164,6 +165,7 @@ class TransitionRouteGroups(scrapi_base.ScrapiBase):
 
         return cx_route_groups
 
+    @scrapi_base.api_call_counter_decorator
     def get_transition_route_group(self, route_group_id):
         """Get a single Transition Route Group object.
 
@@ -183,6 +185,7 @@ class TransitionRouteGroups(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def create_transition_route_group(
         self,
         flow_id: str = None,
@@ -222,6 +225,7 @@ class TransitionRouteGroups(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def update_transition_route_group(
         self,
         route_group_id: str = None,

--- a/src/dfcx_scrapi/core/versions.py
+++ b/src/dfcx_scrapi/core/versions.py
@@ -48,6 +48,7 @@ class Versions(scrapi_base.ScrapiBase):
         if flow_id:
             self.flow_id = flow_id
 
+    @scrapi_base.api_call_counter_decorator
     def list_versions(self, flow_id:str):
         """List all Versions for a given Flow.
 
@@ -79,6 +80,7 @@ class Versions(scrapi_base.ScrapiBase):
 
         return versions
 
+    @scrapi_base.api_call_counter_decorator
     def get_version(
         self,
         version_id:str=None,
@@ -140,6 +142,7 @@ class Versions(scrapi_base.ScrapiBase):
 
         return None
 
+    @scrapi_base.api_call_counter_decorator
     def load_version(
         self,
         version:types.version.Version,
@@ -176,6 +179,7 @@ class Versions(scrapi_base.ScrapiBase):
         response = client.load_version(request)
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def create_version(
         self,
         flow_id:str,
@@ -212,6 +216,7 @@ class Versions(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
     def delete_version(self, version_id:str):
         """Delete a specified Version.
 
@@ -229,6 +234,7 @@ class Versions(scrapi_base.ScrapiBase):
 
         return client.delete_version(request)
 
+    @scrapi_base.api_call_counter_decorator
     def compare_versions(
         self,
         base_version_id:str,

--- a/src/dfcx_scrapi/core/webhooks.py
+++ b/src/dfcx_scrapi/core/webhooks.py
@@ -88,6 +88,7 @@ class Webhooks(scrapi_base.ScrapiBase):
         return webhooks_dict
 
 
+    @scrapi_base.api_call_counter_decorator
     def list_webhooks(self, agent_id: str = None):
         """List all Webhooks in the specified CX Agent.
 
@@ -116,6 +117,7 @@ class Webhooks(scrapi_base.ScrapiBase):
 
         return cx_webhooks
 
+    @scrapi_base.api_call_counter_decorator
     def create_webhook(
         self,
         agent_id: str,
@@ -149,6 +151,7 @@ class Webhooks(scrapi_base.ScrapiBase):
         return response
 
 
+    @scrapi_base.api_call_counter_decorator
     def get_webhook(self, webhook_id:str):
         """Retrieves the specified webhook.
 
@@ -202,6 +205,7 @@ class Webhooks(scrapi_base.ScrapiBase):
         return webhook_obj
 
 
+    @scrapi_base.api_call_counter_decorator
     def update_webhook(
         self,
         webhook_id:str,


### PR DESCRIPTION
### Overall overview

A new feature added to see how many API calls have been made using core methods.

### Changes

Every module we have in the core package has been modified except `sessions.py`. The major additions are in the `ScrapiBase` which are one decorator functions called `api_call_counter_decorator` and two methods `get_api_calls_details` and `get_api_calls_count`.
Each method that makes an API call has been decorated with `api_call_counter_decorator` and now these methods have an attribute called `calls_api` which is equal to `True`.

### Usage

```
from dfcx_scrapi.core.intents import Intents

creds_path = "PATH_TO_CREDS"
agent_id = "SOME_AGENT_ID"

intents_instance = Intents(creds_path=creds_path)

# Make some calls to the API
i_list = intents_instance.list_intents(agent_id=agent_id)
_ = intents_instance.get_intents_map(agent_id=agent_id)
_ = intents_instance.get_intents_map(agent_id=agent_id, reverse=True)
_ = intents_instance.get_intent(i_list[0].name)

# See the API calls
detailed_view = intents_instance.get_api_calls_details()
total_count = intents_instance.get_api_calls_count()
```