### PR TITLE
Feature/delete route group

### DIFF
--- a/src/dfcx_scrapi/core/entity_types.py
+++ b/src/dfcx_scrapi/core/entity_types.py
@@ -421,7 +421,9 @@ class EntityTypes(scrapi_base.ScrapiBase):
         return response
 
     @scrapi_base.api_call_counter_decorator
-    def delete_entity_type(self, entity_id: str = None, obj=None, force: bool = False) -> None:
+    def delete_entity_type(
+        self, entity_id: str = None, obj=None, force: bool = False
+    ) -> str:
         """Deletes a single Entity Type resource object.
 
         Args:

--- a/src/dfcx_scrapi/core/entity_types.py
+++ b/src/dfcx_scrapi/core/entity_types.py
@@ -421,23 +421,27 @@ class EntityTypes(scrapi_base.ScrapiBase):
         return response
 
     @scrapi_base.api_call_counter_decorator
-    def delete_entity_type(self, entity_id: str = None, obj=None) -> None:
+    def delete_entity_type(self, entity_id: str = None, obj=None, force: bool = False) -> None:
         """Deletes a single Entity Type resource object.
 
         Args:
           entity_id: the formatted CX Entity ID to delete
 
         Returns:
-          None
+          String "EntityType `{entity_id}` successfully deleted."
         """
         if not entity_id:
             entity_id = self.entity_id
 
         if obj:
             entity_id = obj.name
-        else:
-            client_options = self._set_region(entity_id)
-            client = services.entity_types.EntityTypesClient(
-                credentials=self.creds, client_options=client_options
-            )
-            client.delete_entity_type(name=entity_id)
+
+
+        client_options = self._set_region(entity_id)
+        client = services.entity_types.EntityTypesClient(
+            credentials=self.creds, client_options=client_options
+        )
+        req = types.DeleteEntityTypeRequest(name=entity_id, force=force)
+        client.delete_entity_type(request=req)
+
+        return f"EntityType `{entity_id}` successfully deleted."

--- a/src/dfcx_scrapi/core/transition_route_groups.py
+++ b/src/dfcx_scrapi/core/transition_route_groups.py
@@ -275,6 +275,38 @@ class TransitionRouteGroups(scrapi_base.ScrapiBase):
 
         return response
 
+    @scrapi_base.api_call_counter_decorator
+    def delete_transition_route_group(
+        self, route_group_id: str, force: bool = False
+    ) -> str:
+        """Deletes the specified Route Group.
+
+        Args:
+          route_group_id: The formatted CX Route Group ID to delete. Format:
+            `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/
+             flows/<Flow ID>/transitionRouteGroups/<Transition Route Group ID>`
+            or
+            `projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/
+             transitionRouteGroups/<Transition Route Group ID>`
+          force: (Optional) This field has no effect for transition route group
+            that no page is using. If set to True, Dialogflow will remove
+            the transition route group, as well as any transitions to the page.
+
+        Returns:
+          String "Route Group `{route_group_id}` successfully deleted."
+        """
+        client_options = self._set_region(route_group_id)
+        client = services.transition_route_groups.TransitionRouteGroupsClient(
+            credentials=self.creds, client_options=client_options
+        )
+        req = types.DeleteTransitionRouteGroupRequest(
+            name=route_group_id, force=force
+        )
+        client.delete_transition_route_group(request=req)
+
+        return f"Route Group `{route_group_id}` successfully deleted."
+
+
     def route_groups_to_dataframe(
         self, agent_id: str = None, rate_limit: float = 0.5
     ):


### PR DESCRIPTION
`delete_transition_route_group` method added.
`force` parameter added for `delete_entity_type`.
bug fix for `delete_entity_type`: if you pass obj, it won't delete the entity type