### PR TITLE
Feature/agent restore option

### DIFF
--- a/src/dfcx_scrapi/core/agents.py
+++ b/src/dfcx_scrapi/core/agents.py
@@ -443,9 +443,6 @@ class Agents(scrapi_base.ScrapiBase):
     ) -> str:
         """Restores a CX agent from a gcs_bucket location.
 
-        Currently there is no way to restore back to default
-        settings via the api. The feature request for this is logged.
-
         Args:
           agent_id: CX Agent ID string in the following format
             projects/<PROJECT ID>/locations/<LOCATION ID>/agents/<AGENT ID>

--- a/src/dfcx_scrapi/core/agents.py
+++ b/src/dfcx_scrapi/core/agents.py
@@ -452,9 +452,10 @@ class Agents(scrapi_base.ScrapiBase):
           gcs_bucket_uri: The Google Cloud Storage bucket/filepath to restore
             the agent from in the following format:
               `gs://<bucket-name>/<object-name>`
-          restore_option: Optional. if not specified, then its equals to 0
+          restore_option: Optional.
+              if not specified, then restore_option = 0 is assumed
               Agent restore mode int in the following value
-              0:unspecificed
+              0:unspecified
               1:always respect the settings from the exported agent file
               2:fallback to default settings if some settings are not supported
 

--- a/src/dfcx_scrapi/core/agents.py
+++ b/src/dfcx_scrapi/core/agents.py
@@ -436,8 +436,8 @@ class Agents(scrapi_base.ScrapiBase):
 
     @scrapi_base.api_call_counter_decorator
     def restore_agent(
-        self, 
-        agent_id: str, 
+        self,
+        agent_id: str,
         gcs_bucket_uri: str,
         restore_option: int = None
     ) -> str:

--- a/src/dfcx_scrapi/core/agents.py
+++ b/src/dfcx_scrapi/core/agents.py
@@ -449,12 +449,12 @@ class Agents(scrapi_base.ScrapiBase):
           gcs_bucket_uri: The Google Cloud Storage bucket/filepath to restore
             the agent from in the following format:
               `gs://<bucket-name>/<object-name>`
-          restore_option: Optional.
+          restore_option: Optional. 
               if not specified, then restore_option = 0 is assumed
-              Agent restore mode int in the following value
-              0:unspecified
-              1:always respect the settings from the exported agent file
-              2:fallback to default settings if some settings are not supported
+              Below are the options for restoring an agent (int):
+                  0:unspecified
+                  1:always respect the settings from the exported agent file
+                  2:fallback to default settings if some settings are not supported
 
         Returns:
           A Long Running Operation (LRO) ID that can be used to

--- a/src/dfcx_scrapi/core/agents.py
+++ b/src/dfcx_scrapi/core/agents.py
@@ -454,7 +454,7 @@ class Agents(scrapi_base.ScrapiBase):
               Below are the options for restoring an agent (int):
                   0:unspecified
                   1:always respect the settings from the exported agent file
-                  2:fallback to default settings if some settings are not supported
+                  2:fallback to default settings if not supported
 
         Returns:
           A Long Running Operation (LRO) ID that can be used to

--- a/src/dfcx_scrapi/core/agents.py
+++ b/src/dfcx_scrapi/core/agents.py
@@ -435,7 +435,12 @@ class Agents(scrapi_base.ScrapiBase):
 
 
     @scrapi_base.api_call_counter_decorator
-    def restore_agent(self, agent_id: str, gcs_bucket_uri: str) -> str:
+    def restore_agent(
+        self, 
+        agent_id: str, 
+        gcs_bucket_uri: str,
+        restore_option: int = None
+    ) -> str:
         """Restores a CX agent from a gcs_bucket location.
 
         Currently there is no way to restore back to default
@@ -447,6 +452,11 @@ class Agents(scrapi_base.ScrapiBase):
           gcs_bucket_uri: The Google Cloud Storage bucket/filepath to restore
             the agent from in the following format:
               `gs://<bucket-name>/<object-name>`
+          restore_option: Optional. if not specified, then its equals to 0
+              Agent restore mode int in the following value
+              0:unspecificed
+              1:always respect the settings from the exported agent file
+              2:fallback to default settings if some settings are not supported
 
         Returns:
           A Long Running Operation (LRO) ID that can be used to
@@ -457,6 +467,11 @@ class Agents(scrapi_base.ScrapiBase):
         request = types.RestoreAgentRequest()
         request.name = agent_id
         request.agent_uri = gcs_bucket_uri
+
+        if restore_option:
+            request.restore_option = types.RestoreAgentRequest.RestoreOption(
+                restore_option
+            )
 
         client_options = self._set_region(agent_id)
         client = services.agents.AgentsClient(


### PR DESCRIPTION
hello, 

I added an optional attribute in restore_agent function that passes the restore_option value when requesting the agent restore in dfcx-scrapi/blob/main/src/dfcx_scrapi/core/agents.py

reference: https://cloud.google.com/python/docs/reference/dialogflow-cx/latest/google.cloud.dialogflowcx_v3beta1.types.RestoreAgentRequest.RestoreOption

Values: RESTORE_OPTION_UNSPECIFIED (0): Unspecified. Treated as KEEP. KEEP (1): Always respect the settings from the exported agent file. It may cause a restoration failure if some settings (e.g. model type) are not supported in the target agent. FALLBACK (2): Fallback to default settings if some settings are not supported in the target agent.




 