### PR TITLE
Feature/test cases util

### DIFF
--- a/src/dfcx_scrapi/tools/test_cases_util.py
+++ b/src/dfcx_scrapi/tools/test_cases_util.py
@@ -29,7 +29,7 @@ logging.basicConfig(
     format="[dfcx] %(levelname)s:%(message)s", level=logging.INFO
 )
 
-class Test_Cases_Util(scrapi_base.ScrapiBase):
+class TestCasesUtil(scrapi_base.ScrapiBase):
     """Util class for CX test cases"""
 
     def __init__(

--- a/src/dfcx_scrapi/tools/test_cases_util.py
+++ b/src/dfcx_scrapi/tools/test_cases_util.py
@@ -557,17 +557,17 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
         logging.info(
             "-- SUCCESS -- DFCX test_case converted -- "
             f"test case: {new_test_case.display_name}")
+
         return new_test_case
 
     def _initialize_conversation_turn(self) -> types.ConversationTurn:
-        """This function initializes the conversation turn.
+        """it initializes the conversation turn.
         Returns:
           types.ConversationTurn
         """
         conversation_turn = types.ConversationTurn()
         conversation_turn.user_input = (
-            conversation_turn.UserInput(input=types.QueryInput())
-        )
+            conversation_turn.UserInput(input=types.QueryInput()))
 
         return conversation_turn
 
@@ -576,8 +576,8 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
         send_obj: Dict,
         conversation_turn: types.ConversationTurn
         ) -> types.ConversationTurn:
-        """This function sets the query input. In query input, there are 4 types
-          of input: text, event, intent, dtmf.
+        """it sets the query input. In query input, it handle 4 types
+          of input: text, event, intent, dtmf if not, then it raises a warning.
         Args:
           conversation_turn: types.ConversationTurn
         Returns:
@@ -590,30 +590,29 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
             conversation_turn.user_input.input.dtmf = (
                 types.DtmfInput(
                     digits=send_obj["dtmf"],
-                    finish_digit=finish_digit)
-            )
+                    finish_digit=finish_digit))
         elif "event" in send_obj:
             conversation_turn.user_input.input.event = (
-                types.EventInput(event=send_obj["event"])
-            )
+                types.EventInput(event=send_obj["event"]))
         elif "text" in send_obj:
             conversation_turn.user_input.input.text = (
-                types.TextInput(text=send_obj["text"])
-            )
+                types.TextInput(text=send_obj["text"]))
         elif "intent" in send_obj:
             conversation_turn.user_input.input.intent = (
-                types.IntentInput(intent=send_obj["intent"])
-            )
+                types.IntentInput(intent=send_obj["intent"]))
+        else:
+            raise UserWarning(
+                "send_obj doesn't contain the proper query input type. "
+                "it must contains one of [text, event, intent, dtmf] as a key")
 
         return conversation_turn
 
     def _convert_send_objs_to_conv_turns(
         self,
-        send_objs: List[Dict],
+        send_objs: list[Dict],
         webhooks: bool) -> List[types.ConversationTurn]:
         """This function converts the send_objs to conversation turns.
-          Iterate through the send_objs and set the params and user input of
-          every turn.
+          Iterate send_objs, set the params and a user_input of every turn.
         Args:
           send_objs: list[dict]
           webhooks: bool
@@ -621,13 +620,7 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
           List[types.ConversationTurn]
         """
         conversation_turns = []
-        input_types = ["text", "event", "intent", "dtmf"]
         for send_obj in send_objs:
-            if not any(input_type in send_obj for input_type in input_types):
-                raise UserWarning(
-                    "send_obj doesn't contain the proper query input type. "
-                    "it must contains [text, event, intent, dtmf] as a key"
-                )
             conversation_turn = self._initialize_conversation_turn()
             if "params" in send_obj:
                 param = Struct()
@@ -636,17 +629,17 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
             conversation_turn.user_input.is_webhook_enabled = webhooks
             conversation_turn = self._set_query_input(
                 send_obj=send_obj,
-                conversation_turn=conversation_turn
-            )
+                conversation_turn=conversation_turn)
             conversation_turns.append(conversation_turn)
         return conversation_turns
 
     def _set_test_config(
         self,
         current_page) -> types.TestConfig:
-        """This method sets the test config.
+        """it sets the test config of the test case.
         if current page is None, then it starts at Default Start Flow/Start page
-        if current page is not None, then it starts at the current page
+        if current page is a page id, then it starts at the specific page id
+        if current page is a flow id, then it starts at the flow start page
         Args:
           current_page: str
         Returns:
@@ -658,22 +651,22 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
                 test_config.page = current_page
             else:
                 test_config.flow = current_page
+
         return test_config
 
     def create_test_case_by_send_objs(
         self,
         display_name: str,
-        send_objs: List[Dict],
+        send_objs: list[Dict],
         webhooks: bool = False,
         current_page: str = None,
         tags: List[str] = None,
         rate_limit: int = 5) ->  Union[types.TestCase, None]:
-        """
-        This function creates a test case by a set of send_objs. Each send_obj
+        """it creates a test case by a set of send_objs. Each send_obj
         consists of params and user input of every turn. Send_obj is commonly
-        used for the e2e testing in dfcx_scrapi.core.conversation.reply
-        function. With this function, it can simultaneously create the test case
-        while running the e2e test.
+        used in the e2e testing, dfcx_scrapi.core.conversation.reply().
+        With this function, it can simultaneously create the test case while
+        running the e2e test.
         Args:
           display_name: a display_name of the test case
           send_objs: a list of send_objs
@@ -707,4 +700,5 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
             logging.error(
                 f"-- ERROR -- ClientError caught on CX.detect -- {err}")
             logging.error("test_case: %s", test_case.display_name)
+
         return response

--- a/src/dfcx_scrapi/tools/test_cases_util.py
+++ b/src/dfcx_scrapi/tools/test_cases_util.py
@@ -24,7 +24,7 @@ from dfcx_scrapi.core import flows
 from dfcx_scrapi.core import pages
 from dfcx_scrapi.core import intents
 from dfcx_scrapi.core import test_cases
-from google.api_core import exceptions as core_exceptions
+from google.api_core import exceptions
 
 logging.basicConfig(
     level=logging.INFO,
@@ -42,7 +42,6 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
         creds=None,
         scope=False,
         agent_id: str = None,
-        test_case_id: str = None,
     ):
         super().__init__(
             creds_path=creds_path,
@@ -156,15 +155,15 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
 
         return updated_test_cases_list
 
-    def _reverse_dict(self, _dict):
-      """Utility method that reverse the dict keys and values
-        Args:
-          _dict: a dictionary
-        Returns:
-          a reversed dictionary
-      """
+    def _reverse_dict(self, dict_):
+        """Utility method that reverse the dict keys and values
+            Args:
+                dict_: a dictionary
+            Returns:
+                a reversed dictionary
+        """
 
-      return {v: k for k, v in _dict.items()}
+        return {v: k for k, v in dict_.items()}
 
     def _get_commons_config(
         self,
@@ -363,8 +362,9 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
         self,
         virtual_agent_output: types.ConversationTurn.VirtualAgentOutput,
         target: dict) -> Union[str, None]:
-        """Attempt to find the intent id from the source's agent conversation turn
-          virtual agent output intent display name to the target's intents map
+        """Attempt to find the intent id from the source's agent 
+        conversation_turn.virtual_agent_output triggered intent
+        display name using the target's intents map
         """
 
         source_intent = (
@@ -518,7 +518,10 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
                 s_commons, t_commons, tc.test_case_conversation_turns)
             new_last_test_conv_turns = self._get_new_conversation_turns(
                 s_commons, t_commons, tc.last_test_result.conversation_turns)
-            if None in [new_test_config, new_conv_turns, new_last_test_conv_turns]:
+            if None in [
+                new_test_config,
+                new_conv_turns,
+                new_last_test_conv_turns]:
                 if not new_test_config:
                     logging.warning(
                         f"test_case: {tc.display_name} "\
@@ -542,7 +545,8 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
                 time.sleep(rate_limit)
             except exceptions.InternalServerError as err:
                 logging.error(
-                    "---- ERROR --- InternalServerError caught on CX.detect %s", err)
+                    "---- ERROR --- InternalServerError caught on CX.detect\
+                    %s", err)
                 logging.error("test_case: %s", tc.display_name)
                 continue
             except exceptions.ClientError as err:

--- a/src/dfcx_scrapi/tools/test_cases_util.py
+++ b/src/dfcx_scrapi/tools/test_cases_util.py
@@ -26,7 +26,9 @@ from dfcx_scrapi.core import intents
 from dfcx_scrapi.core import test_cases
 
 logging.basicConfig(
-    format="[dfcx] %(levelname)s:%(message)s", level=logging.INFO
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
 )
 
 class TestCasesUtil(scrapi_base.ScrapiBase):
@@ -465,7 +467,7 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
         ) -> List[types.TestCase]:
         """The purpose of this method is to create a new set of the test cases
             from (old) a source agent to (new) a target agent.
-            When the new agent (target) is created by the agent builder,
+            When the new agent (target) is created by the copy util,
             UUIDs of flows, pages, intents, and etc are newly generated.
             Therefore, the discrepencies of the uuids creates conflict
             when importing the test cases from a source to a target agent.
@@ -520,6 +522,21 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
                 new_conversation_turns,
                 new_last_test_result_conv_turns
             ]:
+                if not new_test_config:
+                    logging.warning(
+                        f"test_case: {test_case.display_name} "\
+                        f"Reason: test_config is None."
+                    )
+                elif not new_conversation_turns:
+                    logging.warning(
+                        f"test_case: {test_case.display_name} "\
+                        f"Reason: test_conversation_turns is None."
+                    )
+                elif not new_last_test_result_conv_turns:
+                    logging.warning(
+                        f"test_case: {test_case.display_name} "\
+                        f"Reason: last_test_result is None."
+                    )
                 continue
             test_case.test_config = new_test_config
             test_case.test_case_conversation_turns = new_conversation_turns

--- a/src/dfcx_scrapi/tools/test_cases_util.py
+++ b/src/dfcx_scrapi/tools/test_cases_util.py
@@ -609,7 +609,7 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
 
     def _convert_send_objs_to_conv_turns(
         self,
-        send_objs: list[Dict],
+        send_objs: List[Dict],
         webhooks: bool) -> List[types.ConversationTurn]:
         """This function converts the send_objs to conversation turns.
           Iterate through the send_objs and set the params and user input of
@@ -663,7 +663,7 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
     def create_test_case_by_send_objs(
         self,
         display_name: str,
-        send_objs: list[Dict],
+        send_objs: List[Dict],
         webhooks: bool = False,
         current_page: str = None,
         tags: List[str] = None,

--- a/src/dfcx_scrapi/tools/test_cases_util.py
+++ b/src/dfcx_scrapi/tools/test_cases_util.py
@@ -1,0 +1,535 @@
+"""Test Cases Utility functions."""
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Dict, List
+import time
+from google.cloud.dialogflowcx_v3beta1 import types
+
+from dfcx_scrapi.core import scrapi_base
+from dfcx_scrapi.core import flows
+from dfcx_scrapi.core import pages
+from dfcx_scrapi.core import intents
+from dfcx_scrapi.core import test_cases
+
+logging.basicConfig(
+    format="[dfcx] %(levelname)s:%(message)s", level=logging.INFO
+)
+
+class Test_Cases_Util(scrapi_base.ScrapiBase):
+    """Util class for CX test cases"""
+
+    def __init__(
+        self,
+        creds_path: str = None,
+        creds_dict: Dict = None,
+        creds=None,
+        scope=False,
+        agent_id: str = None,
+        test_case_id: str = None,
+    ):
+        super().__init__(
+            creds_path=creds_path,
+            creds_dict=creds_dict,
+            creds=creds,
+            scope=scope,
+        )
+
+        if agent_id:
+            self.agent_id = agent_id
+            self.client_options = self._set_region(self.agent_id)
+
+        if test_case_id:
+            self.test_case_id = test_case_id
+            self.client_options = self._set_region(self.test_case_id)
+
+    def _toggle_sentiment_in_convturns(
+        self,
+        conversation_turns: List[types.ConversationTurn],
+        sentiment: bool
+        ) -> List[types.ConversationTurn]:
+        """Enable/disable enable_sentiment_analysis for all conversation turns.
+        Args:
+            conversation_turns: types.ConversationTurn
+        Returns:
+            a list of the conversation turns
+        """
+        new_conversation_turns = []
+        for conversation_turn in conversation_turns:
+            conversation_turn.user_input.enable_sentiment_analysis = (
+                sentiment
+            )
+            new_conversation_turns.append(conversation_turn)
+
+        return new_conversation_turns
+
+    def toggle_sentiment_test_cases(
+        self,
+        test_case_ids: List[str],
+        sentiment: bool,
+        agent_id: str = None
+        ) -> List[types.TestCase]:
+        """Enable/disable enable_sentiment_analysis for the given test case ids.
+        Args:
+            test_cases: a list of test case ids
+            sentiment:
+                if True then enable_sentiment_analysis = True
+                else disable_sentiment_analysis = False
+            agent_id: The formatted CX Agent ID
+        Returns:
+            a list of the updated test cases
+        """
+        if not agent_id:
+            agent_id = self.agent_id
+        dfcx_testcases = test_cases.TestCases(
+            creds=self.creds,
+            agent_id=agent_id
+        )
+        test_cases_list = dfcx_testcases.list_test_cases(
+            agent_id, include_conversation_turns=True
+            )
+        updated_test_cases_list = []
+        for test_case in test_cases_list:
+            if test_case.name in test_case_ids:
+                test_case.test_case_conversation_turns = (
+                self._toggle_sentiment_in_convturns(
+                    conversation_turns = test_case.test_case_conversation_turns,
+                    sentiment=sentiment
+                    )
+                )
+                updated_test_cases_list.append(test_case)
+
+        return updated_test_cases_list
+
+    def _toggle_webhooks_in_convturns(
+        self,
+        conversation_turns: List[types.ConversationTurn],
+        is_webhook_enabled: bool
+        ) -> List[types.ConversationTurn]:
+        """Sets the webhooks equal to True/False for all conversation turns.
+        Args:
+            conversation_turns: types.ConversationTurn
+        Returns:
+            conversation turns
+        """
+        new_conversation_turns = []
+        for conversation_turn in conversation_turns:
+            conversation_turn.user_input.is_webhook_enabled = (
+                is_webhook_enabled
+            )
+            new_conversation_turns.append(conversation_turn)
+
+        return new_conversation_turns
+
+    def toggle_webhooks_test_cases(
+        self,
+        test_case_ids: List[str],
+        is_webhook_enabled: bool,
+        agent_id: str = None) -> List[types.TestCase]:
+        """
+        Enable/disable webhooks for the given test case ids.
+        Args:
+            test_cases: a list of the test case ids
+            is_webhook_enabled: if enable then True else False
+            agent_id: The formatted CX Agent ID
+        Returns:
+            list of the updated test caess
+        """
+        if not agent_id:
+            agent_id = self.agent_id
+        dfcx_testcases = test_cases.TestCases(
+            creds=self.creds,
+            agent_id=agent_id
+        )
+        test_cases_list = dfcx_testcases.list_test_cases(
+            agent_id, include_conversation_turns=True
+            )
+        updated_test_cases_list = []
+        for test_case in test_cases_list:
+            if test_case.name in test_case_ids:
+                test_case.test_case_conversation_turns = (
+                self._toggle_webhooks_in_convturns(
+                    conversation_turns=(
+                        test_case.test_case_conversation_turns
+                        ),
+                    is_webhook_enabled=is_webhook_enabled
+                    )
+                )
+                updated_test_cases_list.append(test_case)
+
+        return updated_test_cases_list
+
+    def _get_commons_config(
+        self,
+        agent_id: str) -> Dict[str, Dict[str, str]]:
+        """This method map flows, pages, and intents
+            are in the dictionary format
+          Arg:
+            agent_id: The formatted CX Agent ID
+          Returns:
+            a dictionary of flows, pages, and intents
+        """
+        commons_config = {}
+        dfcx_flows = flows.Flows(creds=self.creds, agent_id=agent_id)
+        dfcx_pages = pages.Pages(creds=self.creds)
+        dfcx_intents = intents.Intents(creds=self.creds, agent_id=agent_id)
+        dfcx_intents_map = dfcx_intents.get_intents_map(agent_id=agent_id)
+        dfcx_flows_map = dfcx_flows.get_flows_map(agent_id=agent_id)
+        dfcx_pages_map = {}
+        for flow_id in dfcx_flows_map.keys():
+            dfcx_pages_map[flow_id] = (
+                dfcx_pages.get_pages_map(
+                  flow_id=flow_id
+                )
+            )
+        commons_config["flows"] = dfcx_flows
+        commons_config["pages"] = dfcx_pages
+        commons_config["intents"] = dfcx_intents
+        commons_config["flows_map"] = dfcx_flows_map
+        commons_config["pages_map"] = dfcx_pages_map
+        commons_config["intents_map"] = dfcx_intents_map
+
+        return commons_config
+
+    def _get_new_test_config(
+        self,
+        source: dict,
+        target: dict,
+        test_case: types.TestCase
+        ) -> types.TestConfig:
+        """Update the test case types.test_config to the new types.test_config
+            Update the uuids of flow, page, intent by the display_name
+          args:
+            source: a dictionary of the source agent's flows, pages, and intents
+            target: a dictionary of the target agent's flows, pages, and intents
+            test_case: types.test_config object
+          returns:
+            types.test_config
+        """
+        source_flow_id = self._get_flow_id_from_test_config(
+            test_case
+        )
+        source_page_id = self._get_page_id_from_test_config(
+            test_case, source_flow_id
+        )
+        source_flow = self._get_flow_display_name(
+            source_flow_id, source["flows_map"]
+        )
+        source_page = self._get_page_display_name(
+            source_flow_id, source_page_id, source["pages_map"]
+        )
+        target_test_config = types.TestConfig()
+
+        if test_case.test_config.flow:
+            target_flow_id = self._get_flow_id_by_flow_name(
+                flow_name = source_flow,
+                flows_map = target["flows_map"]
+            )
+            if target_flow_id:
+                target_test_config.flow = target_flow_id
+            else:
+                return None
+
+        elif test_case.test_config.page:
+            target_flow_id = self._get_flow_id_by_flow_name(
+                flow_name = source_flow,
+                flows_map = target["flows_map"]
+            )
+            target_page_id = self._get_page_id_by_page_name(
+                flow_id = target_flow_id,
+                page_name = source_page,
+                pages_map = target["pages_map"]
+            )
+            if target_page_id:
+                target_test_config.page = target_page_id
+            else:
+                return None
+
+        return target_test_config
+
+    def _get_flow_id_from_test_config(
+        self,
+        test_case: types.TestCase) -> str:
+        """Attempt to get the Flow ID from the Test Case Test Config."""
+
+        if "flow" in test_case.test_config:
+            return test_case.test_config.flow
+        elif "page" in test_case.test_config:
+            return "/".join(test_case.test_config.page.split("/")[:8])
+        else:
+            agent_id = "/".join(test_case.name.split("/")[:6])
+            return f"{agent_id}/flows/00000000-0000-0000-0000-000000000000"
+
+    def _get_page_id_from_test_config(
+        self,
+        test_case: types.TestCase,
+        flow_id: str) -> str:
+        """Attempt to get the Page ID from the Test Case Test Config."""
+
+        if "page" in test_case.test_config:
+            return test_case.test_config.page
+        else:
+            return f"{flow_id}/pages/START_PAGE"
+
+    def _get_flow_display_name(
+        self,
+        flow_id: str,
+        flows_map: Dict[str, str]) -> str:
+        """Attempt to get the Flow Display Name from the Flows Map
+            by the flow ID."""
+
+        flow = flows_map.get(flow_id, None)
+        return flow
+
+    def _get_page_display_name(
+        self,
+        flow_id: str,
+        page_id: str,
+        pages_map: Dict[str, Dict[str, str]]) -> str:
+        """Get the Page Display Name from the Pages Map based on the Page ID."""
+
+        page_map = pages_map.get(flow_id, None)
+        page = "START_PAGE"
+
+        if page_map:
+            page = page_map.get(page_id, None)
+
+        return page
+
+    def _get_flow_id_by_flow_name(
+        self,
+        flow_name: str,
+        flows_map: Dict[str, str]) -> str:
+        """Attempt to get the Flow id from the Flows Map
+            by the flow display name."""
+
+        flows_map = {name: id for id, name in flows_map.items()}
+        flow_id = flows_map.get(flow_name, None)
+
+        return flow_id
+
+    def _get_page_id_by_page_name(
+        self,
+        flow_id: str,
+        page_name: str,
+        pages_map: Dict[str, Dict[str, str]]) -> str:
+        """Attempt to get the Page id from the Pages Map
+            by the Page display name."""
+
+        if not flow_id:
+            return None
+
+        page_map = pages_map.get(flow_id, None)
+        page_id = None
+        if  page_name in [
+            "Start Page",
+            "End Flow",
+            "End Session",
+            "End Flow With Failure",
+            "End Flow With Human Escalation",
+            "End Flow With Cancellation"
+            ]:
+            page_name = page_name.upper().replace(" ", "_")
+            page_id = f"{flow_id}/pages/{page_name}"
+        elif page_map:
+            page_map = {name: id for id, name in page_map.items()}
+            page_id = page_map.get(page_name, None)
+
+        return page_id
+
+    def _get_intent_id_by_intent_name(
+        self,
+        intent_name: str,
+        intents_map: Dict[str, str]
+        ) -> str:
+        """Attempt to get the intent id from the Intents Map
+            by the intent's display name."""
+
+        intents_map = {name: id for id, name in intents_map.items()}
+        intent_id = intents_map.get(intent_name, None)
+        return intent_id
+
+    def _get_intent_name_by_intent_id(
+        self,
+        intent_id: str,
+        intents_map: Dict[str, str]
+        ) -> str:
+        """Attempt to get the intent display name from the Intents Map
+            by the intent's display name."""
+
+        intent_name = intents_map.get(intent_id, None)
+        return intent_name
+
+    def _get_new_conversation_turns(
+        self,
+        source: dict,
+        target: dict,
+        conversation_turns: types.ConversationTurn
+        ) -> List[types.ConversationTurn]:
+        """ Update the uuids of the current page and intent
+            by display name in each conversation turn.
+          Args:
+            source: The formatted CX Agent ID
+            target: The formatted CX Agent ID
+            conversation_turns: types.ConversationTurn
+          Returns:
+            types.test_case_conversation_turns
+        """
+
+        new_conversation_turns = []
+        for conv_turn in conversation_turns:
+            if conv_turn.user_input.input.intent:
+                source_intent_id = conv_turn.user_input.input.intent
+                source_intent = self._get_intent_name_by_intent_id(
+                    intent_id = source_intent_id,
+                    intents_map = source["intents_map"]
+                )
+                target_intent_id = self._get_intent_id_by_intent_name(
+                    intent_name = source_intent,
+                    intents_map = target["intents_map"]
+                )
+                if target_intent_id:
+                    conv_turn.user_input.input.intent = target_intent_id
+                else:
+                    return None
+
+            if conv_turn.virtual_agent_output.current_page:
+                source_page = (
+                    conv_turn
+                    .virtual_agent_output
+                    .current_page
+                    .display_name
+                )
+                source_page_id = (
+                    conv_turn.virtual_agent_output.current_page.name
+                )
+                source_flow = self._get_flow_display_name(
+                    flow_id = source_page_id.split("/pages/")[0],
+                    flows_map = source["flows_map"]
+                )
+                target_flow_id = self._get_flow_id_by_flow_name(
+                    flow_name = source_flow,
+                    flows_map = target["flows_map"]
+                )
+                target_page_id = self._get_page_id_by_page_name(
+                    flow_id = target_flow_id,
+                    page_name = source_page,
+                    pages_map = target["pages_map"]
+                )
+                if target_page_id:
+                    conv_turn.virtual_agent_output.current_page.name = (
+                        target_page_id
+                    )
+                else:
+                    return None
+
+            if conv_turn.virtual_agent_output.triggered_intent:
+                source_intent = (
+                    conv_turn
+                    .virtual_agent_output
+                    .triggered_intent.display_name
+                )
+                target_intent_id = self._get_intent_id_by_intent_name(
+                    intent_name = source_intent,
+                    intents_map = target["intents_map"]
+                )
+                if target_intent_id:
+                    conv_turn.virtual_agent_output.triggered_intent.name = (
+                        target_intent_id
+                    )
+                else:
+                    return None
+
+            new_conversation_turns.append(conv_turn)
+
+        return new_conversation_turns
+
+    def migrate_test_cases(
+        self,
+        source_agent: str,
+        target_agent: str,
+        rate_limit: int = 5
+        ) -> List[types.TestCase]:
+        """The purpose of this method is to create a new set of the test cases
+            from (old) a source agent to (new) a target agent.
+            When the new agent (target) is created by the agent builder,
+            UUIDs of flows, pages, intents, and etc are newly generated.
+            Therefore, the discrepencies of the uuids creates conflict
+            when importing the test cases from a source to a target agent.
+            To prevent this, this method helps to migrate the test cases by
+            replacing the UUIDs that are relevant to a target agent. The test
+            cases are only migratable if the display names of flows, pages,
+            intents, and etc have the matching set in both source and target
+            agents.
+          Args:
+            source_agent: The agent that contain the test cases for.
+              Format:
+                `projects/<ProjectID>/locations/<LocationID>/agents/<AgentID>`
+            target_agent: The new agent where you want to migrate.
+              Format:
+                `projects/<ProjectID>/locations/<Location ID>/agents/<AgentID>`
+          Returns:
+            a list of the types.TestCase objects that are created in the
+            target agent.
+        """
+        s_dfcx_test_cases = test_cases.TestCases(
+            creds=self.creds,
+            agent_id=source_agent
+        )
+        t_dfcx_test_cases = test_cases.TestCases(
+            creds=self.creds,
+            agent_id=target_agent
+        )
+        s_agent_tcs = s_dfcx_test_cases.list_test_cases(
+            source_agent,
+            include_conversation_turns=True
+        )
+        if not s_agent_tcs:
+            raise f"source agent:{source_agent} does not have any test cases"
+        new_test_cases = []
+        s_commons = self._get_commons_config(agent_id = source_agent)
+        t_commons = self._get_commons_config(agent_id = target_agent)
+
+        for test_case in s_agent_tcs:
+            new_test_config = self._get_new_test_config(
+                s_commons, t_commons, test_case
+            )
+            new_conversation_turns = self._get_new_conversation_turns(
+                s_commons, t_commons, test_case.test_case_conversation_turns
+            )
+            new_last_test_result_conv_turns = self._get_new_conversation_turns(
+                s_commons,
+                t_commons,
+                test_case.last_test_result.conversation_turns
+            )
+            if None in [
+                new_test_config,
+                new_conversation_turns,
+                new_last_test_result_conv_turns
+            ]:
+                continue
+            test_case.test_config = new_test_config
+            test_case.test_case_conversation_turns = new_conversation_turns
+            test_case.last_test_result.conversation_turns = (
+                new_last_test_result_conv_turns
+            )
+            test_case.name = None
+            new_test_case = t_dfcx_test_cases.create_test_case(
+                test_case=test_case, agent_id=target_agent)
+            time.sleep(rate_limit)
+            new_test_cases.append(new_test_case)
+
+        return new_test_cases

--- a/src/dfcx_scrapi/tools/test_cases_util.py
+++ b/src/dfcx_scrapi/tools/test_cases_util.py
@@ -24,7 +24,7 @@ from dfcx_scrapi.core import flows
 from dfcx_scrapi.core import pages
 from dfcx_scrapi.core import intents
 from dfcx_scrapi.core import test_cases
-from google.api_core import exceptions
+from google.api_core import exceptions as core_exceptions
 
 logging.basicConfig(
     level=logging.INFO,
@@ -543,13 +543,13 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
                 new_test_case = target_dfcx_test_cases.create_test_case(
                     test_case=tc)
                 time.sleep(rate_limit)
-            except exceptions.InternalServerError as err:
+            except core_exceptions.InternalServerError as err:
                 logging.error(
                     "---- ERROR --- InternalServerError caught on CX.detect\
                     %s", err)
                 logging.error("test_case: %s", tc.display_name)
                 continue
-            except exceptions.ClientError as err:
+            except core_exceptions.ClientError as err:
                 logging.error(
                     "---- ERROR --- ClientError caught on CX.detect %s", err)
                 logging.error("test_case: %s", tc.display_name)

--- a/src/dfcx_scrapi/tools/test_cases_util.py
+++ b/src/dfcx_scrapi/tools/test_cases_util.py
@@ -609,12 +609,12 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
 
     def _convert_send_objs_to_conv_turns(
         self,
-        send_objs: list[Dict],
+        send_objs: List[Dict],
         webhooks: bool) -> List[types.ConversationTurn]:
         """This function converts the send_objs to conversation turns.
           Iterate send_objs, set the params and a user_input of every turn.
         Args:
-          send_objs: list[dict]
+          send_objs: List[dict]
           webhooks: bool
         Returns:
           List[types.ConversationTurn]
@@ -657,7 +657,7 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
     def create_test_case_by_send_objs(
         self,
         display_name: str,
-        send_objs: list[Dict],
+        send_objs: List[Dict],
         webhooks: bool = False,
         current_page: str = None,
         tags: List[str] = None,

--- a/src/dfcx_scrapi/tools/test_cases_util.py
+++ b/src/dfcx_scrapi/tools/test_cases_util.py
@@ -475,8 +475,8 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
         test_config: types.TestConfig,
         conv_turns: List[types.ConversationTurn],
         last_test_conv_turns: List[types.ConversationTurn]):
-        """This method is a logger that indicates which attributes are missing
-          from the test case.
+        """This method is a logger that indicates which attributes are not
+        convertible in the test case.
         Args:
           test_config: types.TestConfig
           conv_turns: List[types.ConversationTurn]
@@ -507,6 +507,9 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
         rate_limit: int = 5) -> Union[types.TestCase, None]:
         """This method converts the test case from the source agent to the
           target agent.
+          Note: In dfcx_scrapi.core.test_case.TestCases, it requires
+          list_test_cases(include_conversation_turns=True),
+          Otherwise, it will fail to convert.
         Args:
           test_case: types.TestCase
           source_agent_id: str
@@ -516,6 +519,12 @@ class TestCasesUtil(scrapi_base.ScrapiBase):
           types.TestCase or None if  fails
         """
 
+        if not test_case.test_case_conversation_turns:
+            raise UserWarning(
+                "types.TestCase is not convertible if "
+                "test_case_conversation_turns is empty "
+                f"test case : {test_case.display_name}"
+            )
         if not self.source_commons.get("agent_id") == source_agent_id:
             self.source_commons = self._get_commons_config(
                 agent_id=source_agent_id)


### PR DESCRIPTION
Created the test cases util class that have the following functions

- toggle_webhooks_test_cases : Enable/disable webhooks for the given test case ids. It enables or disables webhooks in each conversation turn. it returns the list of the updated test cases. It gives options to users to either create, update or export/import the test cases.

- toggle_sentiment_test_cases: Enable/disable sentiment analysis for the given test case ids. It enables or disables sentiment analysis in each conversation turn. it returns the list of the updated test cases. It gives options to users to either create, update or export/import the test cases.

- migrate_test_cases: The purpose of this method is to create a new set of the test cases from (old) a source agent to (new) a target agent. When the new agent (target) is created by the copy util, UUIDs of flows, pages, intents, etc are newly generated. Therefore, the discrepancies of the uuids create conflict when importing the test cases from a source to a target agent. To prevent this, this method helps to migrate the test cases by replacing the UUIDs that are relevant to a target agent. The test cases are only migratable if the display names of flows, pages, intents, etc have the matching set in both source and target agents.