### PR TITLE
fix:_check_proto_obj_attr_exist does not handle None properly

### DIFF
--- a/src/dfcx_scrapi/builders/builders_common.py
+++ b/src/dfcx_scrapi/builders/builders_common.py
@@ -43,7 +43,7 @@ class BuildersCommon:
 
     def _check_proto_obj_attr_exist(self):
         """Check if the proto_obj exists otherwise raise an error."""
-        if not self.proto_obj:
+        if self.proto_obj is None:
             raise ValueError(
                 "There is no proto_obj!"
                 "\nUse `create_new_proto_obj` or `load_proto_obj` to continue."


### PR DESCRIPTION
None check in _check_proto_obj_attr_exist is not handled properly. 
``` python
# is buggy for None check.
if not obj:  

# correct way
if obj is None:

# Below code makes one example why it is buggy. 
```

``` python
from dfcx_scrapi.builders.fulfillments import FulfillmentBuilder
from google.cloud.dialogflowcx_v3beta1.types import Fulfillment


def main():
    fulfilment_builder = FulfillmentBuilder()
    fullfilment_obj = fulfilment_builder.create_new_proto_obj()
    assert fulfilment_builder.proto_obj is not None
    assert isinstance(fulfilment_builder.proto_obj, Fulfillment)
    assert isinstance(fullfilment_obj, Fulfillment)

    assert (not fulfilment_builder.proto_obj) is True
    # fails because there is a bug in _check_proto_obj_attr_exist()
    fulfilment_builder._check_proto_obj_attr_exist()

    """
        def _check_proto_obj_attr_exist(self):
        
        # BUG HERE : should be if self.proto_obj is None
        
        if not self.proto_obj:
            raise ValueError(
                "There is no proto_obj!"
                "\nUse `create_new_proto_obj` or `load_proto_obj` to continue."
            )
        elif not isinstance(self.proto_obj, self._proto_type):  # pylint: disable=W1116
            raise ValueError(
                f"proto_obj is not {self._proto_type_str} type."
                "\nPlease create or load the correct type to continue."
            )
    """


if __name__ == "__main__":
    main()
```