### PR TITLE
fix: entity object is not passed properly

### DIFF
--- a/src/dfcx_scrapi/tools/copy_util.py
+++ b/src/dfcx_scrapi/tools/copy_util.py
@@ -444,7 +444,7 @@ class CopyUtil(ScrapiBase):
         for entity in resources_objects["entities"]:
             logging.info("Creating Entity %s...", entity.display_name)
             try:
-                self.entities.create_entity_type(destination_agent, entity)
+                self.entities.create_entity_type(destination_agent, obj=entity)
                 resources_skip_list["entities"].append(entity.display_name)
                 logging.info(
                     "Entity %s created successfully.", entity.display_name


### PR DESCRIPTION
``` python
    # when not pass as key argument entity is passed as display_name which is wrong.
    self.entities.create_entity_type(destination_agent, entity)
    
    def create_entity_type(
        self,
        agent_id: str = None,
        display_name: str = None,
        language_code: str = None,
        obj: types.EntityType = None,
        **kwargs
    ) -> types.EntityType:

```