### PR TITLE
feat: add simply playbook agent creation; update tests

### DIFF
--- a/src/dfcx_scrapi/core/agents.py
+++ b/src/dfcx_scrapi/core/agents.py
@@ -1,6 +1,6 @@
 """Agent Resource functions."""
 
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -223,6 +223,7 @@ class Agents(scrapi_base.ScrapiBase):
         display_name: str = None,
         gcp_region: str = "global",
         obj: types.Agent = None,
+        playbook_agent: bool = False,
         **kwargs,
     ):
         """Create a Dialogflow CX Agent with given display name.
@@ -264,6 +265,12 @@ class Agents(scrapi_base.ScrapiBase):
             # set optional args as agent attributes
             for key, value in kwargs.items():
                 setattr(agent_obj, key, value)
+
+        if playbook_agent:
+            default_playbook_id = "00000000-0000-0000-0000-000000000000"
+            agent_obj.start_playbook = (
+                f"{parent}/agents/-/playbooks/{default_playbook_id}"
+            )
 
         client_options = self._set_region(parent)
         client = services.agents.AgentsClient(
@@ -607,4 +614,4 @@ class Agents(scrapi_base.ScrapiBase):
             credentials=self.creds, client_options=client_options)
         client.delete_agent(name=agent_id)
 
-        return "Agent '{agent_id}' successfully deleted."
+        return f"Agent '{agent_id}' successfully deleted."

--- a/tests/dfcx_scrapi/core/test_agents.py
+++ b/tests/dfcx_scrapi/core/test_agents.py
@@ -87,22 +87,6 @@ def mock_list_agents_pager(mock_list_agents_response):
         mock_list_agents_response,
     )
 
-# Test _list_agents_client_request
-@patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
-def test__list_agents_client_request(
-    mock_client, mock_list_agents_pager, test_config):
-    mock_client.return_value.list_agents.return_value = mock_list_agents_pager
-    agent = Agents()
-    agents = agent._list_agents_client_request(
-        location_id=f"projects/{test_config['project_id']}/locations/global"
-    )
-
-    assert isinstance(agents, list)
-    assert len(agents) == 1
-    assert isinstance(agents[0], types.Agent)
-    assert agents[0].name == test_config["agent_id"]
-    assert agents[0].display_name == test_config["display_name"]
-
 # Test list_agents with location_id
 @patch("dfcx_scrapi.core.agents.Agents._list_agents_client_request")
 def test_list_agents_with_location(mock_list_agents_client_request,
@@ -145,19 +129,19 @@ def test_get_agent(mock_client, mock_agent_obj_flow, test_config):
 @patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
 def test_get_agent_by_display_name_no_location(
     mock_client, mock_agent_obj_flow, mock_list_agents_pager, test_config):
-    mock_client.return_value.get_agent_by_display_name.return_value = mock_agent_obj_flow
+    mock_client.return_value.get_agent_by_display_name.return_value = mock_agent_obj_flow # pylint: disable=C0301
     mock_client.return_value.list_agents.return_value = mock_list_agents_pager
     agent = Agents()
     response = agent.get_agent_by_display_name(
         test_config["project_id"], test_config["display_name"]
         )
 
-    assert response == None
+    assert response is None
 
 @patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
 def test_get_agent_by_display_name_with_region(
     mock_client, mock_agent_obj_flow, mock_list_agents_pager, test_config):
-    mock_client.return_value.get_agent_by_display_name.return_value = mock_agent_obj_flow
+    mock_client.return_value.get_agent_by_display_name.return_value = mock_agent_obj_flow # pylint: disable=C0301
     mock_client.return_value.list_agents.return_value = mock_list_agents_pager
     agent = Agents()
     response = agent.get_agent_by_display_name(
@@ -172,7 +156,8 @@ def test_get_agent_by_display_name_with_region(
 
 # Test create_agent
 @patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
-def test_create_agent_with_kwargs(mock_client, mock_agent_obj_flow, test_config):
+def test_create_agent_with_kwargs(
+    mock_client, mock_agent_obj_flow, test_config):
     mock_client.return_value.create_agent.return_value = mock_agent_obj_flow
     agent = Agents()
     response = agent.create_agent(

--- a/tests/dfcx_scrapi/core/test_agents.py
+++ b/tests/dfcx_scrapi/core/test_agents.py
@@ -20,67 +20,179 @@ import pytest
 from unittest.mock import patch
 
 from google.cloud.dialogflowcx_v3beta1 import types
+from google.cloud.dialogflowcx_v3beta1 import services
+
 from dfcx_scrapi.core.agents import Agents
 
+@pytest.fixture
+def test_config():
+    project_id = "my-project-id-1234"
+    location_id = "global"
+    parent = f"projects/{project_id}/locations/{location_id}"
+    agent_id = f"{parent}/agents/my-agent-1234"
+    display_name = "My Agent Display Name"
+    default_id = "00000000-0000-0000-0000-000000000000"
+    start_flow = f"{agent_id}/flows/{default_id}"
+    start_playbook = f"{agent_id}/playbooks/{default_id}"
+    return {
+        "project_id": project_id,
+        "agent_id": agent_id,
+        "display_name": display_name,
+        "location_id": location_id,
+        "start_flow": start_flow,
+        "start_playbooks": start_playbook
+    }
 
 @pytest.fixture
-def mock_agent_obj():
+def mock_agent_obj_flow(test_config):
     return types.Agent(
-        name="projects/mock-project/locations/global/agents/mock-agent-1234",
-        display_name="Mock Agent",
+        name=test_config["agent_id"],
+        display_name=test_config["display_name"],
         default_language_code="en",
         time_zone="America/Chicago",
+        start_flow=test_config["start_flow"]
     )
-
 
 @pytest.fixture
-def mock_agent_obj_kwargs(mock_agent_obj):
-    mock_agent_obj.description = "This is a Mock Agent description."
-    mock_agent_obj.enable_stackdriver_logging = True
+def mock_agent_obj_playbook(test_config):
+    return types.Agent(
+        name=test_config["agent_id"],
+        display_name=test_config["display_name"],
+        default_language_code="en",
+        time_zone="America/Chicago",
+        start_playbook=test_config["start_playbook"]
+    )
 
-    return mock_agent_obj
+@pytest.fixture
+def mock_agent_obj_kwargs(mock_agent_obj_flow):
+    mock_agent_obj_flow.description = "This is a Mock Agent description."
+    mock_agent_obj_flow.enable_stackdriver_logging = True
 
+    return mock_agent_obj_flow
+
+@pytest.fixture
+def mock_updated_agent_obj(mock_agent_obj_flow):
+    mock_agent_obj_flow.display_name = "Updated Agent Display Name"
+    return mock_agent_obj_flow
+
+@pytest.fixture
+def mock_list_agents_response(mock_agent_obj_flow):
+    return types.agent.ListAgentsResponse(agents=[mock_agent_obj_flow])
+
+@pytest.fixture
+def mock_list_agents_pager(mock_list_agents_response):
+    return services.agents.pagers.ListAgentsPager(
+        services.agents.AgentsClient.list_agents,
+        types.agent.ListAgentsRequest(),
+        mock_list_agents_response,
+    )
+
+# Test _list_agents_client_request
+@patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
+def test__list_agents_client_request(
+    mock_client, mock_list_agents_pager, test_config):
+    mock_client.return_value.list_agents.return_value = mock_list_agents_pager
+    agent = Agents()
+    agents = agent._list_agents_client_request(
+        location_id=f"projects/{test_config['project_id']}/locations/global"
+    )
+
+    assert isinstance(agents, list)
+    assert len(agents) == 1
+    assert isinstance(agents[0], types.Agent)
+    assert agents[0].name == test_config["agent_id"]
+    assert agents[0].display_name == test_config["display_name"]
+
+# Test list_agents with location_id
+@patch("dfcx_scrapi.core.agents.Agents._list_agents_client_request")
+def test_list_agents_with_location(mock_list_agents_client_request,
+                              mock_agent_obj_flow,
+                              test_config
+                              ):
+    mock_list_agents_client_request.return_value = [mock_agent_obj_flow]
+    agent = Agents()
+    agents = agent.list_agents(
+        project_id=test_config["project_id"],
+        location_id="global"
+    )
+    assert isinstance(agents, list)
+    assert isinstance(agents[0], types.agent.Agent)
+    assert agents[0].name == test_config["agent_id"]
+
+# Test list_agents without location_id
+@patch("dfcx_scrapi.core.agents.Agents._list_agents_client_request")
+def test_list_agents_without_location(mock_list_agents_client_request,
+                              mock_agent_obj_flow,
+                              test_config
+                              ):
+    mock_list_agents_client_request.return_value = [mock_agent_obj_flow]
+    agent = Agents()
+    agents = agent.list_agents(project_id=test_config["project_id"])
+    assert isinstance(agents, list)
+    assert isinstance(agents[0], types.agent.Agent)
+    assert agents[0].name == test_config["agent_id"]
+
+# Test get_agent
+@patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
+def test_get_agent(mock_client, mock_agent_obj_flow, test_config):
+    mock_client.return_value.get_agent.return_value = mock_agent_obj_flow
+    agent = Agents()
+    response = agent.get_agent(test_config["agent_id"])
+    assert isinstance(response, types.Agent)
+    assert response.name == test_config["agent_id"]
+    assert response.display_name == test_config["display_name"]
 
 @patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
-def test_create_agent_simple_default_region_no_kwargs(
-    mock_client, mock_agent_obj
-):
-    mock_client.return_value.create_agent.return_value = mock_agent_obj
+def test_get_agent_by_display_name_no_location(
+    mock_client, mock_agent_obj_flow, mock_list_agents_pager, test_config):
+    mock_client.return_value.get_agent_by_display_name.return_value = mock_agent_obj_flow
+    mock_client.return_value.list_agents.return_value = mock_list_agents_pager
+    agent = Agents()
+    response = agent.get_agent_by_display_name(
+        test_config["project_id"], test_config["display_name"]
+        )
+
+    assert response == None
+
+@patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
+def test_get_agent_by_display_name_with_region(
+    mock_client, mock_agent_obj_flow, mock_list_agents_pager, test_config):
+    mock_client.return_value.get_agent_by_display_name.return_value = mock_agent_obj_flow
+    mock_client.return_value.list_agents.return_value = mock_list_agents_pager
+    agent = Agents()
+    response = agent.get_agent_by_display_name(
+        project_id=test_config["project_id"],
+        display_name=test_config["display_name"],
+        region="global"
+        )
+
+    assert isinstance(response, types.Agent)
+    assert response.name == test_config["agent_id"]
+    assert response.display_name == test_config["display_name"]
+
+# Test create_agent
+@patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
+def test_create_agent_with_kwargs(mock_client, mock_agent_obj_flow, test_config):
+    mock_client.return_value.create_agent.return_value = mock_agent_obj_flow
+    agent = Agents()
+    response = agent.create_agent(
+        project_id=test_config["project_id"],
+        display_name=test_config["display_name"]
+    )
+    assert isinstance(response, types.Agent)
+    assert response.name == test_config["agent_id"]
+    assert response.display_name == test_config["display_name"]
+
+@patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
+def test_create_agent_from_obj(mock_client, mock_agent_obj_flow, test_config):
+    mock_client.return_value.create_agent.return_value = mock_agent_obj_flow
 
     agents = Agents()
     res = agents.create_agent(
-        project_id="mock-project", display_name="Mock Agent"
-    )
+        project_id=test_config["project_id"], obj=mock_agent_obj_flow)
 
     assert isinstance(res, types.Agent)
-    assert res.display_name == "Mock Agent"
-
-
-@patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
-def test_create_agent_with_extra_kwargs(mock_client, mock_agent_obj_kwargs):
-    mock_client.return_value.create_agent.return_value = mock_agent_obj_kwargs
-
-    agents = Agents()
-    res = agents.create_agent(
-        project_id="mock-project",
-        display_name="Mock Agent",
-        description="This is a Mock Agent description.",
-        enable_stackdriver_logging=True,
-    )
-
-    assert isinstance(res, types.Agent)
-    assert res == mock_agent_obj_kwargs
-
-
-@patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
-def test_create_agent_from_obj(mock_client, mock_agent_obj):
-    mock_client.return_value.create_agent.return_value = mock_agent_obj
-
-    agents = Agents()
-    res = agents.create_agent(project_id="mock-project", obj=mock_agent_obj)
-
-    assert isinstance(res, types.Agent)
-    assert res.display_name == "Mock Agent"
+    assert res.display_name == test_config["display_name"]
 
 
 @patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
@@ -98,4 +210,76 @@ def test_create_agent_from_obj_with_kwargs(mock_client, mock_agent_obj_kwargs):
     assert isinstance(res, types.Agent)
     assert res.description == "This is a Mock Agent description."
 
-# Next, Restore Agent
+# Test update_agent
+@patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
+def test_update_agent_with_obj(mock_client,
+                             mock_updated_agent_obj,
+                             test_config):
+    mock_client.return_value.update_agent.return_value = (
+        mock_updated_agent_obj
+    )
+    agent = Agents()
+    response = agent.update_agent(
+        agent_id=test_config["agent_id"],
+        obj=mock_updated_agent_obj
+    )
+    assert isinstance(response, types.Agent)
+    assert response.name == test_config["agent_id"]
+    assert response.display_name == "Updated Agent Display Name"
+
+@patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
+def test_update_agent_with_kwargs(mock_client,
+                             mock_agent_obj_flow,
+                             test_config):
+    mock_client.return_value.get_agent.return_value = mock_agent_obj_flow
+    mock_client.return_value.update_agent.return_value = mock_agent_obj_flow
+    agent = Agents()
+    response = agent.update_agent(
+        agent_id=test_config["agent_id"],
+        display_name="Updated Agent Display Name"
+    )
+
+    assert isinstance(response, types.Agent)
+    assert response.name == test_config["agent_id"]
+    assert response.display_name == "Updated Agent Display Name"
+
+# Test delete_agent
+@patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
+def test_delete_agent(test_config):
+    agent = Agents()
+    response = agent.delete_agent(agent_id=test_config["agent_id"])
+    print(response)
+    assert (
+        response == f"Agent '{test_config['agent_id']}' successfully deleted."
+    )
+
+@patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
+def test_create_agent_simple_default_region_no_kwargs(
+    mock_client, mock_agent_obj_flow, test_config
+):
+    mock_client.return_value.create_agent.return_value = mock_agent_obj_flow
+
+    agents = Agents()
+    res = agents.create_agent(
+        project_id=test_config["project_id"],
+        display_name=test_config["display_name"]
+    )
+
+    assert isinstance(res, types.Agent)
+    assert res.display_name == test_config["display_name"]
+
+
+@patch("dfcx_scrapi.core.agents.services.agents.AgentsClient")
+def test_create_agent_with_extra_kwargs(mock_client, mock_agent_obj_kwargs):
+    mock_client.return_value.create_agent.return_value = mock_agent_obj_kwargs
+
+    agents = Agents()
+    res = agents.create_agent(
+        project_id="mock-project",
+        display_name="Mock Agent",
+        description="This is a Mock Agent description.",
+        enable_stackdriver_logging=True,
+    )
+
+    assert isinstance(res, types.Agent)
+    assert res == mock_agent_obj_kwargs


### PR DESCRIPTION
Add a flag for `create_agent` to simplify the creation of a "Default Playbook" agent vs. a "Default Flow" agent.