### PR TITLE
Prevent IndexError in collect_playbook_responses when not in playbook

### DIFF
--- a/src/dfcx_scrapi/core/sessions.py
+++ b/src/dfcx_scrapi/core/sessions.py
@@ -171,13 +171,14 @@ class Sessions(scrapi_base.ScrapiBase):
             else:
                 # If no playbook invocation was found
                 # return the current Playbook
-                playbook_responses.append(
-                    {
-                        "playbook_name": self.get_playbook_name(
-                            res.generative_info.current_playbooks[-1]
-                        )
-                    }
-                )
+                if len(res.generative_info.current_playbooks) > 0:
+                    playbook_responses.append(
+                        {
+                            "playbook_name": self.get_playbook_name(
+                                res.generative_info.current_playbooks[-1]
+                            )
+                        }
+                    )
 
         return playbook_responses
 


### PR DESCRIPTION
When the playbook invokes a flow and ends the turn/session in that flow, collect_playbook_responses was getting an IndexError. This should fix the error in https://github.com/GoogleCloudPlatform/dfcx-scrapi/issues/243

I think we still need to add flow invocations in this evaluation script, though.