### PR TITLE
Update tester.yml

### DIFF
--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.8"
+        python-version: "3.9"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
https://pypi.org/project/google-genai/1.3.0/ 

To use the google-genai library it requires Python >=3.9