### PR TITLE
Fixed a typo summary_spect to summary_spec in Core Search Class

### DIFF
--- a/src/dfcx_scrapi/core/search.py
+++ b/src/dfcx_scrapi/core/search.py
@@ -329,7 +329,7 @@ class Search(scrapi_base.ScrapiBase):
 
             return SearchRequest.ContentSearchSpec(
                 snippet_spec=snippet_spec,
-                summary_spect=summary_spec,
+                summary_spec=summary_spec,
                 extractive_content_spec=extractive_content_spec,
             )
 


### PR DESCRIPTION
Hello, Patrick

While I was working on google.cloud.discoveryengine_v1beta.ContentSearchSpec class to trigger the search function, I noticed a typo which is causing an error. I made a minor change, changing summary_spect to summary_spec. Please review the change. Thank you!

A step to reproduce is below code:
```
from dfcx_scrapi.core.search import Search

search_config = {
    "content_search_spec": {
        "search_result_mode": "CHUNKS"
    },
    "query": "what is the refund policy",
    "page_size": 10,
    "data_store_id": datastore_id
}

s = Search()
res = s.search(search_config)
```
Then the error occurs, ValueError: Unknown field for ContentSearchSpec: summary_spect
```
def build_content_search_spec(
    self, search_request: Dict[str, Any]
) -> Union[SearchRequest.ContentSearchSpec, None]:
    content_spec_dict = search_request.get("content_search_spec", None)
    if content_spec_dict:
        snippet_spec = self.build_snippet_spec()
        summary_spec = self.build_summary_spec(content_spec_dict)
        extractive_content_spec = self.build_extractive_content_spec(
            content_spec_dict
        )

        return SearchRequest.ContentSearchSpec(
            snippet_spec=snippet_spec,
            **summary_spect**=summary_spec,
            extractive_content_spec=extractive_content_spec,
        )

    else:
        return None
```
In the near future, I think it would be good to add the feature in build_content_search_spec function to handle "search_result_mode". But for now, this PR is only for a typo to prevent from the error.

Please refer to this bug report: https://github.com/GoogleCloudPlatform/dfcx-scrapi/issues/285