### PR TITLE
[ADD] Multi-Language Evaluation Support for Evaluation methods

### DIFF
--- a/src/dfcx_scrapi/tools/evaluations.py
+++ b/src/dfcx_scrapi/tools/evaluations.py
@@ -397,7 +397,7 @@ class Evaluations(ScrapiBase):
 
         return df
 
-    def run_detect_intent_queries(self, df: pd.DataFrame) -> pd.DataFrame:
+    def run_detect_intent_queries(self, df: pd.DataFrame, language_code: str = "en") -> pd.DataFrame:
         for index, row in tqdm(df.iterrows(), total=df.shape[0]):
             data = {}
             if row["action_id"] == 1:
@@ -425,7 +425,8 @@ class Evaluations(ScrapiBase):
                 agent_id=self.agent_id,
                 session_id=self.session_id,
                 text=row["action_input"],
-                parameters=session_parameters
+                parameters=session_parameters,
+                language_code=language_code
             )
             # Add data to the existing row
             df.loc[index, ["session_id", "agent_id"]] = [
@@ -512,15 +513,15 @@ class Evaluations(ScrapiBase):
 
         return df
 
-    def scrape_results(self, df: pd.DataFrame) -> pd.DataFrame:
+    def scrape_results(self, df: pd.DataFrame, language_code: str = "en") -> pd.DataFrame:
         df = self.add_response_columns(df)
-        df = self.run_detect_intent_queries(df)
+        df = self.run_detect_intent_queries(df, language_code=language_code)
         df = self.insert_unexpected_rows(df)
 
         return df
 
-    def run_query_and_eval(self, df: pd.DataFrame) -> pd.DataFrame:
-        df = self.scrape_results(df)
+    def run_query_and_eval(self, df: pd.DataFrame, language_code: str = "en") -> pd.DataFrame:
+        df = self.scrape_results(df, language_code=language_code)
         df = self.run_evals(df)
         df = self.clean_outputs(df)
 


### PR DESCRIPTION
# Multi-Language Evaluation Support

The `run_detect_intent_queries`, `scrape_results`, and `run_query_and_eval` methods now support a `language_code` parameter to enable evaluation of agents in different languages.

## Usage Examples

### Basic Usage (English - default)
```python
from dfcx_scrapi.tools.evaluations import Evaluations

# Create evaluations instance
evals = Evaluations(agent_id="your-agent-id", metrics=["response_similarity"])

# Run evaluations in English (default)
results = evals.run_query_and_eval(df)
```

### Multi-Language Usage
```python
# Run evaluations in French Canadian
results_fr = evals.run_query_and_eval(df, language_code="fr-CA")

# Run evaluations in Spanish
results_es = evals.run_query_and_eval(df, language_code="es")

# Run evaluations in German
results_de = evals.run_query_and_eval(df, language_code="de")
```

### Individual Method Usage
```python
# Use language_code with individual methods
results = evals.run_detect_intent_queries(df, language_code="es")
results = evals.scrape_results(df, language_code="es") 
results = evals.run_query_and_eval(df, language_code="es")
```

## Backward Compatibility

All existing code will continue to work without modification, as the `language_code` parameter defaults to "en" (English).

## Supported Language Codes

Use standard language codes as supported by Dialogflow CX :

Refer to the [Dialogflow CX documentation](https://cloud.google.com/dialogflow/cx/docs/reference/language) for the complete list of supported language codes.
