### PR TITLE
[ADD] examples\vertex_ai_conversation\vertex_agents_evals_multilingual.ipynb 

### DIFF
--- a/examples/vertex_ai_conversation/vertex_agents_evals_multilingual.ipynb
+++ b/examples/vertex_ai_conversation/vertex_agents_evals_multilingual.ipynb
@@ -1,0 +1,427 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright 2024 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Vertex Agent Builder and Dialogflow CX Evaluations (+multilingual option)\n",
+    "In this notebook, we will show you how to:\n",
+    "1. Build a new Evaluation Dataset for your Agent.\n",
+    "2. Run the Evaluations to get Quality Metrics\n",
+    "3. Push the Results to Google Sheets for reporting.\n",
+    "\n",
+    "\n",
+    "## Prerequisites\n",
+    "- Existing Agent Builder or DFCX Agent w/ or w/out Tool calling.\n",
+    "<br>\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "  <td style=\"text-align: center\">\n",
+    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/dfcx-scrapi/blob/main/examples/vertex_ai_conversation/vertex_agents_evals.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Google Colaboratory logo\"><br> Run in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td style=\"text-align: center\">\n",
+    "    <a href=\"https://github.com/GoogleCloudPlatform/dfcx-scrapi/blob/main/examples/vertex_ai_conversation/vertex_agents_evals.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\"><br> View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td style=\"text-align: center\">\n",
+    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/dfcx-scrapi/blob/main/examples/vertex_ai_conversation/vertex_agents_evals.ipynb\">\n",
+    "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\"><br> Open in Vertex AI Workbench\n",
+    "    </a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install dfcx-scrapi>=2.0.0\n",
+    "# The language parameter was introduced in 2.0.0, refer to https://github.com/GoogleCloudPlatform/dfcx-scrapi/pull/291\n",
+    "\n",
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    from google.colab import auth\n",
+    "    from google.auth import default\n",
+    "\n",
+    "    auth.authenticate_user()\n",
+    "    credentials, _ = default()\n",
+    "else:\n",
+    "    # Otherwise, attempt to discover local credentials as described in\n",
+    "    # https://cloud.google.com/docs/authentication/application-default-credentials\n",
+    "    pass\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Evaluation Dataset Format\n",
+    "\n",
+    "Collecting and evaluating multi-turn chat data can be complex, so we have devised template that you can follow to make it easy and scalable.\n",
+    "\n",
+    "The evaluation dataset must be in a tabular format and contain the following columns:\n",
+    "- `eval_id` \n",
+    "  - _Unique identifier of a conversation, which must be the same for each row that is part of the same conversation_\n",
+    "- `action_id` \n",
+    "  - _Index of the specific action for the current conversation._\n",
+    "  - _This is used to track and pair responses during inference time._\n",
+    "- `action_type` \n",
+    "  - _The specific action for this turn._\n",
+    "  - _There are currently 4 supported Action Types: `User Utterance`, `Agent Response`, `Playbook Invocation`, `Tool Invocation`_\n",
+    "- `action_input`\n",
+    "  - _The input for this specific action_type._\n",
+    "  - _Based on the specified action_type, this could be the expected user utterance or agent response, the expected Playbook name, or the expected Tool name._\n",
+    "- `action_input_parameters`\n",
+    "  - When `Playbook Invocation` or `Tool Invocation` is selected as the `action_type`, this refers to the payload of information that is expected to be sent with that invocation._\n",
+    "  - _For example, a JSON payload of key/value pairs called with the tool._\n",
+    "- `tool_action`\n",
+    "  - _This field is only used when `Tool Invocation` is chosen as the `action_type`._\n",
+    "  - _This allows us to run evaluations on whether the Tool call chose the correct internal action (if more than one exists)_\n",
+    "- `language_code` **(Optional Metadata)**\n",
+    "  - _The language code for this conversation. This column is useful for organizing your dataset and processing multilingual evaluations._\n",
+    "  - _Use standard language codes as supported by Dialogflow CX [Complete list of supported language codes](https://cloud.google.com/dialogflow/cx/docs/reference/language)._\n",
+    "  - _**Important**: This column is metadata. To evaluate conversations in specific languages, you must:_\n",
+    "    - _Either pass a `language_code` parameter to evaluate all conversations in that language_\n",
+    "    - _Or split your dataframe by this column and process each language separately (see Option 3 in Predict and Evaluate)_\n",
+    "  - _If not specified, the default language code \"en\" (English) is used._\n",
+    "\n",
+    "---\n",
+    "\n",
+    "An example for the queryset can be seen in this table:\n",
+    "\n",
+    "| eval_id | action_id | action_type | action_input | action_input_parameters | tool_action | language_code | notes |\n",
+    "|---|---|---|---|---|---|---|---|\n",
+    "| travel-ai-001 | 1 | User Utterance | Paris |  |  | en |  |\n",
+    "| travel-ai-001 | 2 | Playbook Invocation | Travel Inspiration |  |  | en |  |\n",
+    "| travel-ai-001 | 3 | Agent Response | Paris is a beautiful city! Here are a few things you might enjoy doing there:<br><br>Visit the Eiffel Tower<br>Take a walk along the Champs-Élysées<br>Visit the Louvre Museum<br>See the Arc de Triomphe<br>Take a boat ride on the Seine River |  |  | en |  |\n",
+    "| travel-ai-002 | 1 | User Utterance | Je veux aller à Montréal |  |  | fr-CA |  |\n",
+    "| travel-ai-002 | 2 | Playbook Invocation | Travel Inspiration |  |  | fr-CA |  |\n",
+    "| travel-ai-002 | 3 | Agent Response | Je serais heureux de vous aider à trouver un hôtel à Montréal |  |  | fr-CA |  |\n",
+    "| travel-ai-002 | 4 | User Utterance | Du 1er au 10 juin |  |  | fr-CA |  |\n",
+    "| travel-ai-002 | 5 | Playbook Invocation | Book Hotel |  |  | fr-CA |  |\n",
+    "| travel-ai-002 | 6 | Tool Invocation | hotel_tool | {'city': 'Montreal', 'num_results': 10} | hotel_search | fr-CA |  |\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Data Loading\n",
+    "The preferred method for data loading is to use Google Sheets.  \n",
+    "However you can also manually build your dataset as a Pandas Dataframe, or load from CSV, BQ, etc. as needed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Option 1 - From Google Sheets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dfcx_scrapi.tools.evaluations import DataLoader\n",
+    "\n",
+    "data = DataLoader()\n",
+    "\n",
+    "sheet_name = \"[TEMPLATE] Vertex Agent Evals Dataset Format\"\n",
+    "sheet_tab = \"golden-agent-evals\"\n",
+    "\n",
+    "sample_df = data.from_google_sheets(sheet_name, sheet_tab)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Option 2 - From Local CSV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dfcx_scrapi.tools.evaluations import DataLoader\n",
+    "\n",
+    "data = DataLoader()\n",
+    "\n",
+    "csv_file_path = \"\"\n",
+    "\n",
+    "sample_df = data.from_csv(csv_file_path)\n",
+    "\n",
+    "# If your CSV includes a language_code column, it will be preserved as metadata\n",
+    "# To evaluate conversations in specific languages, use Option 1 or 2 in the \n",
+    "# \"Predict and Evaluate\" section, or process by language (Option 3)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Option 3 - Manual Loading"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from dfcx_scrapi.tools.evaluations import DataLoader\n",
+    "\n",
+    "data = DataLoader()\n",
+    "\n",
+    "# Include language_code as optional metadata column\n",
+    "INPUT_SCHEMA_REQUIRED_COLUMNS = ['eval_id', 'action_id', 'action_type', 'action_input', 'action_input_parameters', 'tool_action', 'language_code', 'notes']\n",
+    "\n",
+    "sample_df = pd.DataFrame(columns=INPUT_SCHEMA_REQUIRED_COLUMNS)\n",
+    "\n",
+    "# English examples\n",
+    "sample_df.loc[0] = [\"travel-ai-001\", 1, \"User Utterance\", \"Paris\", \"\", \"\", \"en\", \"\"]\n",
+    "sample_df.loc[1] = [\"travel-ai-001\", 2, \"Playbook Invocation\", \"Travel Inspiration\", \"\", \"\", \"en\", \"\"]\n",
+    "sample_df.loc[2] = [\"travel-ai-001\", 3, \"Agent Response\", \"Paris is a beautiful city! Here are a few things you might enjoy doing there:\\n\\nVisit the Eiffel Tower\\nTake a walk along the Champs-Élysées\\nVisit the Louvre Museum\\nSee the Arc de Triomphe\\nTake a boat ride on the Seine River\", \"\", \"\", \"en\", \"\"]\n",
+    "\n",
+    "# French-Canadian examples (same conversation ID pattern can be used)\n",
+    "sample_df.loc[3] = [\"travel-ai-002\", 1, \"User Utterance\", \"Je veux aller à Montréal\", \"\", \"\", \"fr-CA\", \"\"]\n",
+    "sample_df.loc[4] = [\"travel-ai-002\", 2, \"Playbook Invocation\", \"Travel Inspiration\", \"\", \"\", \"fr-CA\", \"\"]\n",
+    "sample_df.loc[5] = [\"travel-ai-002\", 3, \"Agent Response\", \"Je serais heureux de vous aider à trouver un hôtel à Montréal\", \"\", \"\", \"fr-CA\", \"\"]\n",
+    "\n",
+    "sample_df = data.from_dataframe(sample_df)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Metrics\n",
+    "For multi-turn chat Agents w/ or w/out tool calling, there are currently 2 metrics supported:\n",
+    "1. `Response Similarity`, this performs a Semantic Similarity comparison between the expected \"golden\" response and the actual \"predicted\" response\n",
+    "2. `Tool Call Quality`, this performs and EXACT_MATCH on 2 components of the Tool call\n",
+    "    - Tool Name, i.e. was the correct Tool invoked\n",
+    "    - Tool Action, i.e. for the given Tool, was the correct Action / Endpoint invoked\n",
+    "\n",
+    "Other metrics like `UrlMatch`, `Faithfulness`, `Answer Correctness`, `Context Recall` etc. will be supported in the future.\n",
+    "\n",
+    "## Language Support\n",
+    "All metrics support evaluation across different languages via the `language_code` parameter:\n",
+    "- **Default language**: `\"en\"` (English) if `language_code` is not specified\n",
+    "- **Global override**: Pass `language_code` parameter to evaluate all queries in a specific language (e.g., `language_code=\"fr-CA\"`)\n",
+    "- **Note**: The `language_code` column in your dataframe is metadata. To use it, you must explicitly process each language group separately (see Option 3 in the Predict and Evaluate section)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dfcx_scrapi.tools.evaluations import Evaluations\n",
+    "\n",
+    "# [1] Define your Agent ID here\n",
+    "agent_id = \"projects/your-project/locations/us-central1/agents/11111-2222-33333-44444\" # Example Agent\n",
+    "\n",
+    "# [2] Instantiate Evals class w/ Metrics\n",
+    "evals = Evaluations(agent_id, metrics=[\"response_similarity\", \"tool_call_quality\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Predict and Evaluate\n",
+    "In this step, we will run all of the queries against the Agent that is being evaluated.  \n",
+    "Once the queries are returned, we will then compute all of the metrics.\n",
+    "\n",
+    "## Language Code Handling\n",
+    "\n",
+    "The `run_query_and_eval()` method signature is: `run_query_and_eval(df, language_code=\"en\")`\n",
+    "\n",
+    "Thre are three approaches for handling language codes:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Option 1: Default to English (Recommended for single-language datasets)\n",
+    "If your dataset contains only one language or you want to evaluate everything in English by default:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# OPTION 1: Default to English (ignores language_code column)\n",
+    "eval_results = evals.run_query_and_eval(sample_df.head(10))\n",
+    "\n",
+    "print(f\"Average Similarity {eval_results.similarity.mean()}\")\n",
+    "print(f\"Average Tool Call Quality {eval_results.tool_name_match.mean()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Option 2: Override Default Language (Recommended for single-language evaluation)\n",
+    "If you want all queries evaluated in a specific language other than English:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eval_results = evals.run_query_and_eval(sample_df.head(10), language_code=\"fr-CA\")\n",
+    "\n",
+    "print(f\"Average Similarity {eval_results.similarity.mean()}\")\n",
+    "print(f\"Average Tool Call Quality {eval_results.tool_name_match.mean()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Option 3: Split by Language and Process Separately (For multilingual datasets)\n",
+    "If your dataset contains conversations in **multiple different languages**, you must split by language and process each separately:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "all_results = []\n",
+    "for language_code, language_df in sample_df.groupby('language_code'):\n",
+    "    print(f\"Processing language: {language_code} ({len(language_df)} rows)...\")\n",
+    "    # Pass the language_code parameter explicitly\n",
+    "    results = evals.run_query_and_eval(language_df.head(10), language_code=language_code)\n",
+    "    results['language'] = language_code  # Add language label to results\n",
+    "    all_results.append(results)\n",
+    "\n",
+    "# Combine all results\n",
+    "eval_results = pd.concat(all_results, ignore_index=True)\n",
+    "\n",
+    "# Restore original order if needed (sort by eval_id or another identifier)\n",
+    "# eval_results = eval_results.sort_values('eval_id').reset_index(drop=True)\n",
+    "\n",
+    "# Analyze by language\n",
+    "print(\"\\nResults by Language:\")\n",
+    "for language in eval_results['language'].unique():\n",
+    "    lang_results = eval_results[eval_results['language'] == language]\n",
+    "    print(f\"{language}: Avg Similarity = {lang_results.similarity.mean():.4f}\")\n",
+    "    print(f\"{language}: Avg Tool Call Quality = {lang_results.tool_name_match.mean():.4f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# You can inspect the results as needed\n",
+    "eval_results.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Write to Google Sheets\n",
+    "Storing the evaluation results to Google Sheets can be done with the following snippets.\n",
+    "\n",
+    "In future revisions, we will add export to other format including `csv`, `bigquery`, etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dfcx_scrapi.tools.evaluations import DataLoader\n",
+    "\n",
+    "data = DataLoader()\n",
+    "\n",
+    "data.write_eval_results_to_sheets(eval_results, sheet_name, results_tab=\"latest_results\")\n",
+    "data.append_test_results_to_sheets(eval_results, sheet_name, summary_tab=\"reporting\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ending and Wrap-Up\n",
+    "\n",
+    "In this notebook, we've shown how to programmatically Evaluate your Agent Builder or Dialogflow CX Agent.\n",
+    "\n",
+    "For more information, see:\n",
+    "- [Vertex AI Agents](https://cloud.google.com/dialogflow/vertex/docs/concept/agents)\n",
+    "- [Dialogflow CX](https://cloud.google.com/dialogflow/cx/docs)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Description
Add a new dedicated notebook for evaluating Dialogflow CX and Vertex AI Agent Builder agents across multiple languages using the `language_code` parameter support introduced in dfcx-scrapi v2.0.0 (#291).

## Changes
- **New file**: `examples/vertex_ai_conversation/vertex_agents_evals_multilingual.ipynb`

## What's Included

### Dataset Format
- Enhanced documentation of the `language_code` column as optional metadata
- Clear examples with English and French-Canadian sample conversations

### Three Language Handling Approaches
1. **Option 1: Default English** - Evaluate all queries in English
   ```python
   eval_results = evals.run_query_and_eval(sample_df)
   ```

2. **Option 2: Override Language** - Evaluate all queries in a specific language
   ```python
   eval_results = evals.run_query_and_eval(sample_df, language_code="fr-CA")
   ```

3. **Option 3: Split by Language** - Process each language separately (multilingual datasets)
   ```python
   for language_code, language_df in sample_df.groupby('language_code'):
       results = evals.run_query_and_eval(language_df, language_code=language_code)
   ```

### Key Features
- Clear explanation that `language_code` must be explicitly passed as a parameter
- Per-language metrics analysis examples

## Testing
- Notebook structure follows existing examples format
- Syntax validated with Python 3.11
- Examples use sample data (no external dependencies beyond dfcx-scrapi)

## Notes for Reviewers
- This is a **new** notebook, separate from the existing `vertex_agents_evals.ipynb`
- The original notebook remains unchanged for single-language and beginner workflows
- All code examples are functional and follow dfcx-scrapi v2.0.0+
